### PR TITLE
Bugfix: merge classes and root elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.3.2
+- fixes base class merge (root level elements)
+
 ## Version 0.3.1
 - fixes base class merge (override duplicates)
 

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -221,6 +221,10 @@ class PackageApiAnalyzer {
       }
     }
 
+    // remove collected elements that don't have their class collected
+    collectedClasses.removeWhere(
+        (key, value) => key != null && value.classDeclarations.isEmpty);
+
     if (mergeBaseClasses) {
       _mergeSuperTypes(collectedClasses);
     }


### PR DESCRIPTION
If a package has root elements (without class context) the merge classes functionality crashes.
This PR fixes that behavior