### PR TITLE
use latest dart-apitool (from current branch) additionally in GH workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,24 @@ jobs:
       flutter-channel: 'any'
       flutter-version: ${{ needs.get_flutter_version.outputs.flutter-version }}
 
+  semver-dogfood:
+    needs: [get_last_released_version, get_flutter_version]
+    runs-on: sh_devmil_mac
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '${{ inputs.flutter-version }}'
+          channel: '${{ inputs.flutter-channel }}'
+          cache-path: '${{ runner.tool_cache }}/flutter-${{ needs.get_flutter_version.outputs.flutter-version }}-any'
+
+      - name: check version
+        run: dart bin/main.dart diff --old pub://dart_apitool/${{ needs.get_last_released_version.outputs.last_released_version }} --new . --ignore-prerelease on
+
   test:
     needs: [check_label, get_flutter_version]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
           channel: '${{ inputs.flutter-channel }}'
           cache-path: '${{ runner.tool_cache }}/flutter-${{ needs.get_flutter_version.outputs.flutter-version }}-any'
 
+      - name: Install dependencies
+        run: dart pub get
+        
       - name: check version
         run: dart bin/main.dart diff --old pub://dart_apitool/${{ needs.get_last_released_version.outputs.last_released_version }} --new . --ignore-prerelease on
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_apitool
-description: A tool for Dart APIs. It allows to create a model of the public API of a given package as well as comparing two different models and provide the needed version jump.
+description: A tool to analyze the public API of a package and create a model of it. It also allows to use that model to compare the public API with a newer version and check if the version follows [semver](https://semver.org) correctly.
 homepage: https://devmil.de
 repository: https://github.com/devmil/dart_apitool
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_apitool
-description: A tool to analyze the public API of a package and create a model of it. It also allows to use that model to compare the public API with a newer version and check if the version follows [semver](https://semver.org) correctly.
+description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 homepage: https://devmil.de
 repository: https://github.com/devmil/dart_apitool
 


### PR DESCRIPTION
This PR adds another GH action step to use the dart-apitool from the current branch additionally to the latest released one