### PR TITLE
[Fix] treat extensions as classes

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.3.3",
+  "flutterSdkVersion": "3.3.5",
   "flavors": {}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
         run: dart pub get
 
       - name: Verify Builder have been run
-        run: dart pub run build_runner build --delete-conflicting-outputs && git diff --quiet HEAD
+        run: |
+          dart pub run build_runner build --delete-conflicting-outputs 
+          git diff --exit-code HEAD
 
       - name: Analyze project source
         run: dart analyze

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Version 0.6.1
-- Fixes Extension handling (are now treated as classes)
+## Version 0.7.0
+- *BREAKING*: renamed "Class" model elements to "Interface" to reflect the abstraction it represents
+- Fixes Extension handling (are now treated as interfaces)
   
 ## Version 0.6.0
 - *BREAKING*: removes capability to use stored models in diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.6.1
+- Fixes Extension handling (are now treated as classes)
+  
 ## Version 0.6.0
 - *BREAKING*: removes capability to use stored models in diffs
 - *BREAKING*: CommandMixin's "analyze" no longer does clean up preparation results. For this the newly introduced "cleanUp" method has to be called

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -319,10 +319,23 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
   @override
   void visitExtensionElement(ExtensionElement element) {
     _onVisitAnyElement(element);
-    super.visitExtensionElement(element);
+    if (element.name != null && !_isNameExported(element.name!)) {
+      return;
+    }
+    if (!_isElementAllowedToBeCollected(element)) {
+      return;
+    }
+    if (!_markElementAsCollected(element)) {
+      return;
+    }
+    _classDeclarations.add(InternalClassDeclaration.fromExtensionElement(
+        element,
+        namespace: _context.namespace));
     if (element.extendedType.element != null) {
       _onTypeUsed(element.extendedType, element);
     }
+
+    super.visitExtensionElement(element);
   }
 }
 

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -164,45 +164,47 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     return true;
   }
 
-  @override
-  void visitClassElement(ClassElement element) {
-    _onVisitAnyElement(element);
-    if (!_isNameExported(element.name)) {
-      return;
+  bool _onVisitInterfaceElement(InterfaceElement interfaceElement) {
+    _onVisitAnyElement(interfaceElement);
+    if (!_isNameExported(interfaceElement.name)) {
+      return false;
     }
-    if (!_isElementAllowedToBeCollected(element)) {
-      return;
+    if (!_isElementAllowedToBeCollected(interfaceElement)) {
+      return false;
     }
-    if (!_markElementAsCollected(element)) {
-      return;
+    if (!_markElementAsCollected(interfaceElement)) {
+      return false;
     }
     _classDeclarations.add(InternalClassDeclaration.fromInterfaceElement(
-        element,
+        interfaceElement,
         namespace: _context.namespace));
-    for (final st in element.allSupertypes) {
+    for (final st in interfaceElement.allSupertypes) {
       if (!st.isDartCoreObject && !st.isDartCoreEnum) {
-        _onTypeUsed(st, element);
+        _onTypeUsed(st, interfaceElement);
       }
     }
-    super.visitClassElement(element);
+    return true;
+  }
+
+  @override
+  void visitClassElement(ClassElement element) {
+    if (_onVisitInterfaceElement(element)) {
+      super.visitClassElement(element);
+    }
   }
 
   @override
   void visitEnumElement(EnumElement element) {
-    _onVisitAnyElement(element);
-    if (!_isNameExported(element.name)) {
-      return;
+    if (_onVisitInterfaceElement(element)) {
+      super.visitEnumElement(element);
     }
-    if (!_isElementAllowedToBeCollected(element)) {
-      return;
+  }
+
+  @override
+  void visitMixinElement(MixinElement element) {
+    if (_onVisitInterfaceElement(element)) {
+      super.visitMixinElement(element);
     }
-    if (!_markElementAsCollected(element)) {
-      return;
-    }
-    _classDeclarations.add(InternalClassDeclaration.fromInterfaceElement(
-        element,
-        namespace: _context.namespace));
-    super.visitEnumElement(element);
   }
 
   @override

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -7,14 +7,14 @@ import 'package:analyzer/dart/element/visitor.dart';
 
 import '../model/internal/internal_type_alias_declaration.dart';
 import '../utils/string_utils.dart';
-import '../model/internal/internal_class_declaration.dart';
+import '../model/internal/internal_interface_declaration.dart';
 import '../model/internal/internal_executable_declaration.dart';
 import '../model/internal/internal_field_declaration.dart';
 
 /// collector to get all the API relevant information out of an AST
 ///
 /// It tracks the found elements in its public properties:
-/// - [classDeclarations]
+/// - [interfaceDeclarations]
 /// - [executableDeclarations]
 /// - [fieldDeclarations]
 /// - [typeAliasDeclarations]
@@ -49,13 +49,14 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
 
   String? _packageName;
 
-  final List<InternalClassDeclaration> _classDeclarations = [];
+  final List<InternalInterfaceDeclaration> _interfaceDeclarations = [];
   final List<InternalExecutableDeclaration> _executableDeclarations = [];
   final List<InternalFieldDeclaration> _fieldDeclarations = [];
   final List<InternalTypeAliasDeclaration> _typeAliasDeclarations = [];
 
   /// all found class declarations
-  List<InternalClassDeclaration> get classDeclarations => _classDeclarations;
+  List<InternalInterfaceDeclaration> get interfaceDeclarations =>
+      _interfaceDeclarations;
 
   /// all found executable declarations (like methods and constructors)
   List<InternalExecutableDeclaration> get executableDeclarations =>
@@ -114,7 +115,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
       directElement.accept(collector);
       // merge result with this result
       _collectedElementIds.addAll(collector._collectedElementIds);
-      classDeclarations.addAll(collector.classDeclarations);
+      interfaceDeclarations.addAll(collector.interfaceDeclarations);
       executableDeclarations.addAll(collector.executableDeclarations);
       fieldDeclarations.addAll(collector.fieldDeclarations);
       typeAliasDeclarations.addAll(collector.typeAliasDeclarations);
@@ -175,9 +176,9 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     if (!_markElementAsCollected(interfaceElement)) {
       return false;
     }
-    _classDeclarations.add(InternalClassDeclaration.fromInterfaceElement(
-        interfaceElement,
-        namespace: _context.namespace));
+    _interfaceDeclarations.add(
+        InternalInterfaceDeclaration.fromInterfaceElement(interfaceElement,
+            namespace: _context.namespace));
     for (final st in interfaceElement.allSupertypes) {
       if (!st.isDartCoreObject && !st.isDartCoreEnum) {
         _onTypeUsed(st, interfaceElement);
@@ -349,9 +350,9 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     if (!_markElementAsCollected(element)) {
       return;
     }
-    _classDeclarations.add(InternalClassDeclaration.fromExtensionElement(
-        element,
-        namespace: _context.namespace));
+    _interfaceDeclarations.add(
+        InternalInterfaceDeclaration.fromExtensionElement(element,
+            namespace: _context.namespace));
     if (element.extendedType.element2 != null) {
       _onTypeUsed(element.extendedType, element);
     }

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -176,14 +176,33 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     if (!_markElementAsCollected(element)) {
       return;
     }
-    _classDeclarations.add(InternalClassDeclaration.fromClassElement(element,
+    _classDeclarations.add(InternalClassDeclaration.fromInterfaceElement(
+        element,
         namespace: _context.namespace));
     for (final st in element.allSupertypes) {
-      if (!st.element.isDartCoreObject && !st.element.isDartCoreEnum) {
+      if (!st.isDartCoreObject && !st.isDartCoreEnum) {
         _onTypeUsed(st, element);
       }
     }
     super.visitClassElement(element);
+  }
+
+  @override
+  void visitEnumElement(EnumElement element) {
+    _onVisitAnyElement(element);
+    if (!_isNameExported(element.name)) {
+      return;
+    }
+    if (!_isElementAllowedToBeCollected(element)) {
+      return;
+    }
+    if (!_markElementAsCollected(element)) {
+      return;
+    }
+    _classDeclarations.add(InternalClassDeclaration.fromInterfaceElement(
+        element,
+        namespace: _context.namespace));
+    super.visitEnumElement(element);
   }
 
   @override
@@ -198,7 +217,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     _fieldDeclarations
         .add(InternalFieldDeclaration.fromPropertyInducingElement(element));
     super.visitFieldElement(element);
-    if (element.type.element != null) {
+    if (element.type.element2 != null) {
       _onTypeUsed(element.type, element);
     }
   }
@@ -217,7 +236,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
       namespace: _context.namespace,
     ));
     super.visitTopLevelVariableElement(element);
-    if (element.type.element != null) {
+    if (element.type.element2 != null) {
       _onTypeUsed(element.type, element);
     }
   }
@@ -227,7 +246,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     _onVisitAnyElement(element);
     super.visitParameterElement(element);
     // this includes method, function and constructor calls
-    if (element.type.element != null) {
+    if (element.type.element2 != null) {
       _onTypeUsed(element.type, element);
     }
   }
@@ -246,7 +265,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
       element,
     ));
     super.visitMethodElement(element);
-    if (element.returnType.element != null) {
+    if (element.returnType.element2 != null) {
       _onTypeUsed(element.returnType, element);
     }
   }
@@ -302,7 +321,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
       namespace: _context.namespace,
     ));
     super.visitTypeAliasElement(element);
-    if (element.aliasedType.element != null) {
+    if (element.aliasedType.element2 != null) {
       _onTypeUsed(element.aliasedType, element);
     }
   }
@@ -311,7 +330,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
   visitTypeParameterElement(TypeParameterElement element) {
     _onVisitAnyElement(element);
     super.visitTypeParameterElement(element);
-    if (element.bound?.element != null) {
+    if (element.bound?.element2 != null) {
       _onTypeUsed(element.bound!, element);
     }
   }
@@ -331,7 +350,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     _classDeclarations.add(InternalClassDeclaration.fromExtensionElement(
         element,
         namespace: _context.namespace));
-    if (element.extendedType.element != null) {
+    if (element.extendedType.element2 != null) {
       _onTypeUsed(element.extendedType, element);
     }
 

--- a/lib/src/analyze/package_api_analyzer.freezed.dart
+++ b/lib/src/analyze/package_api_analyzer.freezed.dart
@@ -30,7 +30,8 @@ mixin _$_FileToAnalyzeEntry {
 abstract class _$FileToAnalyzeEntryCopyWith<$Res> {
   factory _$FileToAnalyzeEntryCopyWith(
           _FileToAnalyzeEntry value, $Res Function(_FileToAnalyzeEntry) then) =
-      __$FileToAnalyzeEntryCopyWithImpl<$Res>;
+      __$FileToAnalyzeEntryCopyWithImpl<$Res, _FileToAnalyzeEntry>;
+  @useResult
   $Res call(
       {String filePath,
       List<String> shownNames,
@@ -39,39 +40,41 @@ abstract class _$FileToAnalyzeEntryCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$FileToAnalyzeEntryCopyWithImpl<$Res>
+class __$FileToAnalyzeEntryCopyWithImpl<$Res, $Val extends _FileToAnalyzeEntry>
     implements _$FileToAnalyzeEntryCopyWith<$Res> {
   __$FileToAnalyzeEntryCopyWithImpl(this._value, this._then);
 
-  final _FileToAnalyzeEntry _value;
   // ignore: unused_field
-  final $Res Function(_FileToAnalyzeEntry) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? filePath = freezed,
-    Object? shownNames = freezed,
-    Object? hiddenNames = freezed,
-    Object? exportedBy = freezed,
+    Object? filePath = null,
+    Object? shownNames = null,
+    Object? hiddenNames = null,
+    Object? exportedBy = null,
   }) {
     return _then(_value.copyWith(
-      filePath: filePath == freezed
+      filePath: null == filePath
           ? _value.filePath
           : filePath // ignore: cast_nullable_to_non_nullable
               as String,
-      shownNames: shownNames == freezed
+      shownNames: null == shownNames
           ? _value.shownNames
           : shownNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      hiddenNames: hiddenNames == freezed
+      hiddenNames: null == hiddenNames
           ? _value.hiddenNames
           : hiddenNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      exportedBy: exportedBy == freezed
+      exportedBy: null == exportedBy
           ? _value.exportedBy
           : exportedBy // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -82,6 +85,7 @@ abstract class _$$__FileToAnalyzeEntryCopyWith<$Res>
           $Res Function(_$__FileToAnalyzeEntry) then) =
       __$$__FileToAnalyzeEntryCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String filePath,
       List<String> shownNames,
@@ -91,36 +95,34 @@ abstract class _$$__FileToAnalyzeEntryCopyWith<$Res>
 
 /// @nodoc
 class __$$__FileToAnalyzeEntryCopyWithImpl<$Res>
-    extends __$FileToAnalyzeEntryCopyWithImpl<$Res>
+    extends __$FileToAnalyzeEntryCopyWithImpl<$Res, _$__FileToAnalyzeEntry>
     implements _$$__FileToAnalyzeEntryCopyWith<$Res> {
   __$$__FileToAnalyzeEntryCopyWithImpl(_$__FileToAnalyzeEntry _value,
       $Res Function(_$__FileToAnalyzeEntry) _then)
-      : super(_value, (v) => _then(v as _$__FileToAnalyzeEntry));
+      : super(_value, _then);
 
-  @override
-  _$__FileToAnalyzeEntry get _value => super._value as _$__FileToAnalyzeEntry;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? filePath = freezed,
-    Object? shownNames = freezed,
-    Object? hiddenNames = freezed,
-    Object? exportedBy = freezed,
+    Object? filePath = null,
+    Object? shownNames = null,
+    Object? hiddenNames = null,
+    Object? exportedBy = null,
   }) {
     return _then(_$__FileToAnalyzeEntry(
-      filePath: filePath == freezed
+      filePath: null == filePath
           ? _value.filePath
           : filePath // ignore: cast_nullable_to_non_nullable
               as String,
-      shownNames: shownNames == freezed
+      shownNames: null == shownNames
           ? _value._shownNames
           : shownNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      hiddenNames: hiddenNames == freezed
+      hiddenNames: null == hiddenNames
           ? _value._hiddenNames
           : hiddenNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      exportedBy: exportedBy == freezed
+      exportedBy: null == exportedBy
           ? _value._exportedBy
           : exportedBy // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -175,7 +177,8 @@ class _$__FileToAnalyzeEntry implements __FileToAnalyzeEntry {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$__FileToAnalyzeEntry &&
-            const DeepCollectionEquality().equals(other.filePath, filePath) &&
+            (identical(other.filePath, filePath) ||
+                other.filePath == filePath) &&
             const DeepCollectionEquality()
                 .equals(other._shownNames, _shownNames) &&
             const DeepCollectionEquality()
@@ -187,13 +190,14 @@ class _$__FileToAnalyzeEntry implements __FileToAnalyzeEntry {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(filePath),
+      filePath,
       const DeepCollectionEquality().hash(_shownNames),
       const DeepCollectionEquality().hash(_hiddenNames),
       const DeepCollectionEquality().hash(_exportedBy));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$__FileToAnalyzeEntryCopyWith<_$__FileToAnalyzeEntry> get copyWith =>
       __$$__FileToAnalyzeEntryCopyWithImpl<_$__FileToAnalyzeEntry>(
           this, _$identity);

--- a/lib/src/analyze/package_api_analyzer.freezed.dart
+++ b/lib/src/analyze/package_api_analyzer.freezed.dart
@@ -30,8 +30,7 @@ mixin _$_FileToAnalyzeEntry {
 abstract class _$FileToAnalyzeEntryCopyWith<$Res> {
   factory _$FileToAnalyzeEntryCopyWith(
           _FileToAnalyzeEntry value, $Res Function(_FileToAnalyzeEntry) then) =
-      __$FileToAnalyzeEntryCopyWithImpl<$Res, _FileToAnalyzeEntry>;
-  @useResult
+      __$FileToAnalyzeEntryCopyWithImpl<$Res>;
   $Res call(
       {String filePath,
       List<String> shownNames,
@@ -40,41 +39,39 @@ abstract class _$FileToAnalyzeEntryCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$FileToAnalyzeEntryCopyWithImpl<$Res, $Val extends _FileToAnalyzeEntry>
+class __$FileToAnalyzeEntryCopyWithImpl<$Res>
     implements _$FileToAnalyzeEntryCopyWith<$Res> {
   __$FileToAnalyzeEntryCopyWithImpl(this._value, this._then);
 
+  final _FileToAnalyzeEntry _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(_FileToAnalyzeEntry) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? filePath = null,
-    Object? shownNames = null,
-    Object? hiddenNames = null,
-    Object? exportedBy = null,
+    Object? filePath = freezed,
+    Object? shownNames = freezed,
+    Object? hiddenNames = freezed,
+    Object? exportedBy = freezed,
   }) {
     return _then(_value.copyWith(
-      filePath: null == filePath
+      filePath: filePath == freezed
           ? _value.filePath
           : filePath // ignore: cast_nullable_to_non_nullable
               as String,
-      shownNames: null == shownNames
+      shownNames: shownNames == freezed
           ? _value.shownNames
           : shownNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      hiddenNames: null == hiddenNames
+      hiddenNames: hiddenNames == freezed
           ? _value.hiddenNames
           : hiddenNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      exportedBy: null == exportedBy
+      exportedBy: exportedBy == freezed
           ? _value.exportedBy
           : exportedBy // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ) as $Val);
+    ));
   }
 }
 
@@ -85,7 +82,6 @@ abstract class _$$__FileToAnalyzeEntryCopyWith<$Res>
           $Res Function(_$__FileToAnalyzeEntry) then) =
       __$$__FileToAnalyzeEntryCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String filePath,
       List<String> shownNames,
@@ -95,34 +91,36 @@ abstract class _$$__FileToAnalyzeEntryCopyWith<$Res>
 
 /// @nodoc
 class __$$__FileToAnalyzeEntryCopyWithImpl<$Res>
-    extends __$FileToAnalyzeEntryCopyWithImpl<$Res, _$__FileToAnalyzeEntry>
+    extends __$FileToAnalyzeEntryCopyWithImpl<$Res>
     implements _$$__FileToAnalyzeEntryCopyWith<$Res> {
   __$$__FileToAnalyzeEntryCopyWithImpl(_$__FileToAnalyzeEntry _value,
       $Res Function(_$__FileToAnalyzeEntry) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$__FileToAnalyzeEntry));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$__FileToAnalyzeEntry get _value => super._value as _$__FileToAnalyzeEntry;
+
   @override
   $Res call({
-    Object? filePath = null,
-    Object? shownNames = null,
-    Object? hiddenNames = null,
-    Object? exportedBy = null,
+    Object? filePath = freezed,
+    Object? shownNames = freezed,
+    Object? hiddenNames = freezed,
+    Object? exportedBy = freezed,
   }) {
     return _then(_$__FileToAnalyzeEntry(
-      filePath: null == filePath
+      filePath: filePath == freezed
           ? _value.filePath
           : filePath // ignore: cast_nullable_to_non_nullable
               as String,
-      shownNames: null == shownNames
+      shownNames: shownNames == freezed
           ? _value._shownNames
           : shownNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      hiddenNames: null == hiddenNames
+      hiddenNames: hiddenNames == freezed
           ? _value._hiddenNames
           : hiddenNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      exportedBy: null == exportedBy
+      exportedBy: exportedBy == freezed
           ? _value._exportedBy
           : exportedBy // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -177,8 +175,7 @@ class _$__FileToAnalyzeEntry implements __FileToAnalyzeEntry {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$__FileToAnalyzeEntry &&
-            (identical(other.filePath, filePath) ||
-                other.filePath == filePath) &&
+            const DeepCollectionEquality().equals(other.filePath, filePath) &&
             const DeepCollectionEquality()
                 .equals(other._shownNames, _shownNames) &&
             const DeepCollectionEquality()
@@ -190,14 +187,13 @@ class _$__FileToAnalyzeEntry implements __FileToAnalyzeEntry {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      filePath,
+      const DeepCollectionEquality().hash(filePath),
       const DeepCollectionEquality().hash(_shownNames),
       const DeepCollectionEquality().hash(_hiddenNames),
       const DeepCollectionEquality().hash(_exportedBy));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$__FileToAnalyzeEntryCopyWith<_$__FileToAnalyzeEntry> get copyWith =>
       __$$__FileToAnalyzeEntryCopyWithImpl<_$__FileToAnalyzeEntry>(
           this, _$identity);

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -42,7 +42,7 @@ Package reference can be one of:
   /// Analyzes the given prepared Package [ref].
   /// If the prepared package contains anything that has to be cleaned up
   /// (like created temp directories) then [analyze] takes care of that
-  /// [doMergeBaseClasses] defines if base classes should be merged into derived ones. This allows to remove private base classes from the list of class declarations.
+  /// [doMergeBaseClasses] defines if base classes should be merged into derived ones. This allows to remove private base classes from the list of interface declarations.
   /// [doAnalyzePlatformConstraints] defines if the platform constraints of the package shall be analyzed.
   Future<PackageApi> analyze(
     PreparedPackageRef preparedRef, {

--- a/lib/src/cli/commands/diff_command.dart
+++ b/lib/src/cli/commands/diff_command.dart
@@ -160,7 +160,7 @@ You may want to do this if you want to make sure
       }
     } else if (declaration is FieldDeclaration) {
       prefix = 'Field ';
-    } else if (declaration is ClassDeclaration) {
+    } else if (declaration is InterfaceDeclaration) {
       prefix = 'Class ';
     }
     return prefix + declaration.name;

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -38,8 +38,8 @@ class PackageApiDiffer {
 
     try {
       final changes = [
-        ..._calculateClassesDiff(oldApi.classDeclarations,
-            newApi.classDeclarations, Stack<Declaration>()),
+        ..._calculateInterfacesDiff(oldApi.interfaceDeclarations,
+            newApi.interfaceDeclarations, Stack<Declaration>()),
         ..._calculateExecutablesDiff(
           oldApi.executableDeclarations,
           newApi.executableDeclarations,
@@ -72,65 +72,67 @@ class PackageApiDiffer {
     }
   }
 
-  List<ApiChange> _calculateClassesDiff(List<ClassDeclaration> oldClasses,
-      List<ClassDeclaration> newClasses, Stack<Declaration> context) {
-    final classListDiff = _diffIterables<ClassDeclaration>(
-      oldClasses,
-      newClasses,
-      (oldClass, newClass) => oldClass.name == newClass.name,
+  List<ApiChange> _calculateInterfacesDiff(
+      List<InterfaceDeclaration> oldInterfaces,
+      List<InterfaceDeclaration> newInterfaces,
+      Stack<Declaration> context) {
+    final interfaceListDiff = _diffIterables<InterfaceDeclaration>(
+      oldInterfaces,
+      newInterfaces,
+      (oldInterface, newInterface) => oldInterface.name == newInterface.name,
     );
     final changes = <ApiChange>[];
-    for (final oldClass in classListDiff.matches.keys) {
-      changes.addAll(_calculateClassDiff(
-        oldClass,
-        classListDiff.matches[oldClass]!,
+    for (final oldInterface in interfaceListDiff.matches.keys) {
+      changes.addAll(_calculateInterfaceDiff(
+        oldInterface,
+        interfaceListDiff.matches[oldInterface]!,
         context,
       ));
     }
-    for (final removedClass in classListDiff.remainingOld) {
+    for (final removedInterface in interfaceListDiff.remainingOld) {
       changes.add(ApiChange(
-        affectedDeclaration: removedClass,
+        affectedDeclaration: removedInterface,
         contextTrace: _contextTraceFromStack(context),
         type: ApiChangeType.remove,
-        changeDescription: 'Class "${removedClass.name}" removed',
+        changeDescription: 'Interface "${removedInterface.name}" removed',
       ));
     }
-    for (final addedClass in classListDiff.remainingNew) {
+    for (final addedInterface in interfaceListDiff.remainingNew) {
       changes.add(ApiChange(
-        affectedDeclaration: addedClass,
+        affectedDeclaration: addedInterface,
         contextTrace: _contextTraceFromStack(context),
         type: ApiChangeType.addCompatible,
-        changeDescription: 'Class "${addedClass.name}" added',
+        changeDescription: 'Interface "${addedInterface.name}" added',
       ));
     }
     return changes;
   }
 
-  List<ApiChange> _calculateClassDiff(
-    ClassDeclaration oldClass,
-    ClassDeclaration newClass,
+  List<ApiChange> _calculateInterfaceDiff(
+    InterfaceDeclaration oldInterface,
+    InterfaceDeclaration newInterface,
     Stack<Declaration> context,
   ) {
-    return _executeInContext(context, newClass, (context) {
+    return _executeInContext(context, newInterface, (context) {
       final changes = [
-        ..._calculateExecutablesDiff(oldClass.executableDeclarations,
-            newClass.executableDeclarations, context),
-        ..._calculateFieldsDiff(
-            oldClass.fieldDeclarations, newClass.fieldDeclarations, context),
+        ..._calculateExecutablesDiff(oldInterface.executableDeclarations,
+            newInterface.executableDeclarations, context),
+        ..._calculateFieldsDiff(oldInterface.fieldDeclarations,
+            newInterface.fieldDeclarations, context),
         ..._calculateSuperTypesDiff(
-            oldClass.superTypeNames, newClass.superTypeNames, context),
-        ..._calculateTypeParametersDiff(
-            oldClass.typeParameterNames, newClass.typeParameterNames, context),
+            oldInterface.superTypeNames, newInterface.superTypeNames, context),
+        ..._calculateTypeParametersDiff(oldInterface.typeParameterNames,
+            newInterface.typeParameterNames, context),
         ..._calculateEntryPointsDiff(
-            oldClass.entryPoints, newClass.entryPoints, context)
+            oldInterface.entryPoints, newInterface.entryPoints, context)
       ];
 
       _comparePropertiesAndAddChange(
-        oldClass.isDeprecated,
-        newClass.isDeprecated,
+        oldInterface.isDeprecated,
+        newInterface.isDeprecated,
         context,
-        newClass,
-        'Deprecated Flag changed. ${oldClass.isDeprecated} -> ${newClass.isDeprecated}',
+        newInterface,
+        'Deprecated Flag changed. ${oldInterface.isDeprecated} -> ${newInterface.isDeprecated}',
         changes,
         isCompatibleChange: true,
       );
@@ -177,12 +179,12 @@ class PackageApiDiffer {
     return changes;
   }
 
-  String _getExecutableTypeName(ExecutableType type, bool inClassContext) {
+  String _getExecutableTypeName(ExecutableType type, bool inInterfaceContext) {
     switch (type) {
       case ExecutableType.constructor:
         return 'Constructor';
       case ExecutableType.method:
-        return inClassContext ? 'Method' : 'Function';
+        return inInterfaceContext ? 'Method' : 'Function';
     }
   }
 

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -36,35 +36,40 @@ class PackageApiDiffer {
               'Given models have different semantics. Old Package: ${oldApi.semantics}, New Package: ${newApi.semantics}');
     }
 
-    final changes = [
-      ..._calculateClassesDiff(oldApi.classDeclarations,
-          newApi.classDeclarations, Stack<Declaration>()),
-      ..._calculateExecutablesDiff(
-        oldApi.executableDeclarations,
-        newApi.executableDeclarations,
-        Stack<Declaration>(),
-      ),
-      ..._calculateFieldsDiff(
-        oldApi.fieldDeclarations,
-        newApi.fieldDeclarations,
-        Stack<Declaration>(),
-      ),
-      ..._calculateIOSPlatformConstraintsDiff(
-        oldApi.iosPlatformConstraints,
-        newApi.iosPlatformConstraints,
-      ),
-      ..._calculateAndroidPlatformConstraintsDiff(
-        oldApi.androidPlatformConstraints,
-        newApi.androidPlatformConstraints,
-      ),
-      if (options.doCheckSdkVersion)
-        ..._calculateSdkDiff(
-          oldApi,
-          newApi,
+    try {
+      final changes = [
+        ..._calculateClassesDiff(oldApi.classDeclarations,
+            newApi.classDeclarations, Stack<Declaration>()),
+        ..._calculateExecutablesDiff(
+          oldApi.executableDeclarations,
+          newApi.executableDeclarations,
+          Stack<Declaration>(),
         ),
-    ];
+        ..._calculateFieldsDiff(
+          oldApi.fieldDeclarations,
+          newApi.fieldDeclarations,
+          Stack<Declaration>(),
+        ),
+        ..._calculateIOSPlatformConstraintsDiff(
+          oldApi.iosPlatformConstraints,
+          newApi.iosPlatformConstraints,
+        ),
+        ..._calculateAndroidPlatformConstraintsDiff(
+          oldApi.androidPlatformConstraints,
+          newApi.androidPlatformConstraints,
+        ),
+        if (options.doCheckSdkVersion)
+          ..._calculateSdkDiff(
+            oldApi,
+            newApi,
+          ),
+      ];
 
-    return PackageApiDiffResult()..addApiChanges(changes);
+      return PackageApiDiffResult()..addApiChanges(changes);
+    } on Object catch (e, t) {
+      throw PackageApiDiffError(
+          message: 'Error while creating the diff: $e $t');
+    }
   }
 
   List<ApiChange> _calculateClassesDiff(List<ClassDeclaration> oldClasses,

--- a/lib/src/model/class_declaration.freezed.dart
+++ b/lib/src/model/class_declaration.freezed.dart
@@ -35,7 +35,8 @@ mixin _$ClassDeclaration {
 abstract class $ClassDeclarationCopyWith<$Res> {
   factory $ClassDeclarationCopyWith(
           ClassDeclaration value, $Res Function(ClassDeclaration) then) =
-      _$ClassDeclarationCopyWithImpl<$Res>;
+      _$ClassDeclarationCopyWithImpl<$Res, ClassDeclaration>;
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -47,54 +48,56 @@ abstract class $ClassDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ClassDeclarationCopyWithImpl<$Res>
+class _$ClassDeclarationCopyWithImpl<$Res, $Val extends ClassDeclaration>
     implements $ClassDeclarationCopyWith<$Res> {
   _$ClassDeclarationCopyWithImpl(this._value, this._then);
 
-  final ClassDeclaration _value;
   // ignore: unused_field
-  final $Res Function(ClassDeclaration) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -105,6 +108,7 @@ abstract class _$$_ClassDeclarationCopyWith<$Res>
           _$_ClassDeclaration value, $Res Function(_$_ClassDeclaration) then) =
       __$$_ClassDeclarationCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -117,51 +121,49 @@ abstract class _$$_ClassDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_ClassDeclarationCopyWithImpl<$Res>
-    extends _$ClassDeclarationCopyWithImpl<$Res>
+    extends _$ClassDeclarationCopyWithImpl<$Res, _$_ClassDeclaration>
     implements _$$_ClassDeclarationCopyWith<$Res> {
   __$$_ClassDeclarationCopyWithImpl(
       _$_ClassDeclaration _value, $Res Function(_$_ClassDeclaration) _then)
-      : super(_value, (v) => _then(v as _$_ClassDeclaration));
+      : super(_value, _then);
 
-  @override
-  _$_ClassDeclaration get _value => super._value as _$_ClassDeclaration;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_ClassDeclaration(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value._superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -238,9 +240,9 @@ class _$_ClassDeclaration extends _ClassDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ClassDeclaration &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -256,8 +258,8 @@ class _$_ClassDeclaration extends _ClassDeclaration {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
+      name,
+      isDeprecated,
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -266,6 +268,7 @@ class _$_ClassDeclaration extends _ClassDeclaration {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ClassDeclarationCopyWith<_$_ClassDeclaration> get copyWith =>
       __$$_ClassDeclarationCopyWithImpl<_$_ClassDeclaration>(this, _$identity);
 }

--- a/lib/src/model/executable_declaration.freezed.dart
+++ b/lib/src/model/executable_declaration.freezed.dart
@@ -41,9 +41,7 @@ abstract class $ExecutableParameterDeclarationCopyWith<$Res> {
   factory $ExecutableParameterDeclarationCopyWith(
           ExecutableParameterDeclaration value,
           $Res Function(ExecutableParameterDeclaration) then) =
-      _$ExecutableParameterDeclarationCopyWithImpl<$Res,
-          ExecutableParameterDeclaration>;
-  @useResult
+      _$ExecutableParameterDeclarationCopyWithImpl<$Res>;
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -53,47 +51,44 @@ abstract class $ExecutableParameterDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableParameterDeclarationCopyWithImpl<$Res,
-        $Val extends ExecutableParameterDeclaration>
+class _$ExecutableParameterDeclarationCopyWithImpl<$Res>
     implements $ExecutableParameterDeclarationCopyWith<$Res> {
   _$ExecutableParameterDeclarationCopyWithImpl(this._value, this._then);
 
+  final ExecutableParameterDeclaration _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(ExecutableParameterDeclaration) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isRequired = null,
-    Object? isNamed = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeName = null,
+    Object? isRequired = freezed,
+    Object? isNamed = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeName = freezed,
   }) {
     return _then(_value.copyWith(
-      isRequired: null == isRequired
+      isRequired: isRequired == freezed
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: null == isNamed
+      isNamed: isNamed == freezed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-    ) as $Val);
+    ));
   }
 }
 
@@ -105,7 +100,6 @@ abstract class _$$_ExecutableParameterDeclarationCopyWith<$Res>
           $Res Function(_$_ExecutableParameterDeclaration) then) =
       __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -116,41 +110,43 @@ abstract class _$$_ExecutableParameterDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>
-    extends _$ExecutableParameterDeclarationCopyWithImpl<$Res,
-        _$_ExecutableParameterDeclaration>
+    extends _$ExecutableParameterDeclarationCopyWithImpl<$Res>
     implements _$$_ExecutableParameterDeclarationCopyWith<$Res> {
   __$$_ExecutableParameterDeclarationCopyWithImpl(
       _$_ExecutableParameterDeclaration _value,
       $Res Function(_$_ExecutableParameterDeclaration) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_ExecutableParameterDeclaration));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_ExecutableParameterDeclaration get _value =>
+      super._value as _$_ExecutableParameterDeclaration;
+
   @override
   $Res call({
-    Object? isRequired = null,
-    Object? isNamed = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeName = null,
+    Object? isRequired = freezed,
+    Object? isNamed = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeName = freezed,
   }) {
     return _then(_$_ExecutableParameterDeclaration(
-      isRequired: null == isRequired
+      isRequired: isRequired == freezed
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: null == isNamed
+      isNamed: isNamed == freezed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
@@ -200,23 +196,26 @@ class _$_ExecutableParameterDeclaration
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableParameterDeclaration &&
-            (identical(other.isRequired, isRequired) ||
-                other.isRequired == isRequired) &&
-            (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
-            (identical(other.typeName, typeName) ||
-                other.typeName == typeName));
+            const DeepCollectionEquality()
+                .equals(other.isRequired, isRequired) &&
+            const DeepCollectionEquality().equals(other.isNamed, isNamed) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
+            const DeepCollectionEquality().equals(other.typeName, typeName));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, isRequired, isNamed, name, isDeprecated, typeName);
+      runtimeType,
+      const DeepCollectionEquality().hash(isRequired),
+      const DeepCollectionEquality().hash(isNamed),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
+      const DeepCollectionEquality().hash(typeName));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_ExecutableParameterDeclarationCopyWith<_$_ExecutableParameterDeclaration>
       get copyWith => __$$_ExecutableParameterDeclarationCopyWithImpl<
           _$_ExecutableParameterDeclaration>(this, _$identity);
@@ -279,8 +278,7 @@ mixin _$ExecutableDeclaration {
 abstract class $ExecutableDeclarationCopyWith<$Res> {
   factory $ExecutableDeclarationCopyWith(ExecutableDeclaration value,
           $Res Function(ExecutableDeclaration) then) =
-      _$ExecutableDeclarationCopyWithImpl<$Res, ExecutableDeclaration>;
-  @useResult
+      _$ExecutableDeclarationCopyWithImpl<$Res>;
   $Res call(
       {String returnTypeName,
       String name,
@@ -293,62 +291,59 @@ abstract class $ExecutableDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableDeclarationCopyWithImpl<$Res,
-        $Val extends ExecutableDeclaration>
+class _$ExecutableDeclarationCopyWithImpl<$Res>
     implements $ExecutableDeclarationCopyWith<$Res> {
   _$ExecutableDeclarationCopyWithImpl(this._value, this._then);
 
+  final ExecutableDeclaration _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(ExecutableDeclaration) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? returnTypeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? parameters = null,
-    Object? typeParameterNames = null,
-    Object? type = null,
-    Object? isStatic = null,
+    Object? returnTypeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? parameters = freezed,
+    Object? typeParameterNames = freezed,
+    Object? type = freezed,
+    Object? isStatic = freezed,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      returnTypeName: null == returnTypeName
+      returnTypeName: returnTypeName == freezed
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: null == parameters
+      parameters: parameters == freezed
           ? _value.parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclaration>,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: null == type
+      type: type == freezed
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableType,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ) as $Val);
+    ));
   }
 }
 
@@ -359,7 +354,6 @@ abstract class _$$_ExecutableDeclarationCopyWith<$Res>
           $Res Function(_$_ExecutableDeclaration) then) =
       __$$_ExecutableDeclarationCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String returnTypeName,
       String name,
@@ -373,54 +367,57 @@ abstract class _$$_ExecutableDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableDeclarationCopyWithImpl<$Res>
-    extends _$ExecutableDeclarationCopyWithImpl<$Res, _$_ExecutableDeclaration>
+    extends _$ExecutableDeclarationCopyWithImpl<$Res>
     implements _$$_ExecutableDeclarationCopyWith<$Res> {
   __$$_ExecutableDeclarationCopyWithImpl(_$_ExecutableDeclaration _value,
       $Res Function(_$_ExecutableDeclaration) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_ExecutableDeclaration));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_ExecutableDeclaration get _value =>
+      super._value as _$_ExecutableDeclaration;
+
   @override
   $Res call({
-    Object? returnTypeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? parameters = null,
-    Object? typeParameterNames = null,
-    Object? type = null,
-    Object? isStatic = null,
+    Object? returnTypeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? parameters = freezed,
+    Object? typeParameterNames = freezed,
+    Object? type = freezed,
+    Object? isStatic = freezed,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_ExecutableDeclaration(
-      returnTypeName: null == returnTypeName
+      returnTypeName: returnTypeName == freezed
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: null == parameters
+      parameters: parameters == freezed
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclaration>,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: null == type
+      type: type == freezed
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableType,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -488,18 +485,17 @@ class _$_ExecutableDeclaration extends _ExecutableDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableDeclaration &&
-            (identical(other.returnTypeName, returnTypeName) ||
-                other.returnTypeName == returnTypeName) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
+            const DeepCollectionEquality()
+                .equals(other.returnTypeName, returnTypeName) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.isStatic, isStatic) ||
-                other.isStatic == isStatic) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
@@ -507,18 +503,17 @@ class _$_ExecutableDeclaration extends _ExecutableDeclaration {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      returnTypeName,
-      name,
-      isDeprecated,
+      const DeepCollectionEquality().hash(returnTypeName),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
       const DeepCollectionEquality().hash(_parameters),
       const DeepCollectionEquality().hash(_typeParameterNames),
-      type,
-      isStatic,
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(isStatic),
       const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_ExecutableDeclarationCopyWith<_$_ExecutableDeclaration> get copyWith =>
       __$$_ExecutableDeclarationCopyWithImpl<_$_ExecutableDeclaration>(
           this, _$identity);

--- a/lib/src/model/executable_declaration.freezed.dart
+++ b/lib/src/model/executable_declaration.freezed.dart
@@ -41,7 +41,9 @@ abstract class $ExecutableParameterDeclarationCopyWith<$Res> {
   factory $ExecutableParameterDeclarationCopyWith(
           ExecutableParameterDeclaration value,
           $Res Function(ExecutableParameterDeclaration) then) =
-      _$ExecutableParameterDeclarationCopyWithImpl<$Res>;
+      _$ExecutableParameterDeclarationCopyWithImpl<$Res,
+          ExecutableParameterDeclaration>;
+  @useResult
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -51,44 +53,47 @@ abstract class $ExecutableParameterDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableParameterDeclarationCopyWithImpl<$Res>
+class _$ExecutableParameterDeclarationCopyWithImpl<$Res,
+        $Val extends ExecutableParameterDeclaration>
     implements $ExecutableParameterDeclarationCopyWith<$Res> {
   _$ExecutableParameterDeclarationCopyWithImpl(this._value, this._then);
 
-  final ExecutableParameterDeclaration _value;
   // ignore: unused_field
-  final $Res Function(ExecutableParameterDeclaration) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isRequired = freezed,
-    Object? isNamed = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeName = freezed,
+    Object? isRequired = null,
+    Object? isNamed = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeName = null,
   }) {
     return _then(_value.copyWith(
-      isRequired: isRequired == freezed
+      isRequired: null == isRequired
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: isNamed == freezed
+      isNamed: null == isNamed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-    ));
+    ) as $Val);
   }
 }
 
@@ -100,6 +105,7 @@ abstract class _$$_ExecutableParameterDeclarationCopyWith<$Res>
           $Res Function(_$_ExecutableParameterDeclaration) then) =
       __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -110,43 +116,41 @@ abstract class _$$_ExecutableParameterDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>
-    extends _$ExecutableParameterDeclarationCopyWithImpl<$Res>
+    extends _$ExecutableParameterDeclarationCopyWithImpl<$Res,
+        _$_ExecutableParameterDeclaration>
     implements _$$_ExecutableParameterDeclarationCopyWith<$Res> {
   __$$_ExecutableParameterDeclarationCopyWithImpl(
       _$_ExecutableParameterDeclaration _value,
       $Res Function(_$_ExecutableParameterDeclaration) _then)
-      : super(_value, (v) => _then(v as _$_ExecutableParameterDeclaration));
+      : super(_value, _then);
 
-  @override
-  _$_ExecutableParameterDeclaration get _value =>
-      super._value as _$_ExecutableParameterDeclaration;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isRequired = freezed,
-    Object? isNamed = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeName = freezed,
+    Object? isRequired = null,
+    Object? isNamed = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeName = null,
   }) {
     return _then(_$_ExecutableParameterDeclaration(
-      isRequired: isRequired == freezed
+      isRequired: null == isRequired
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: isNamed == freezed
+      isNamed: null == isNamed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
@@ -196,26 +200,23 @@ class _$_ExecutableParameterDeclaration
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableParameterDeclaration &&
-            const DeepCollectionEquality()
-                .equals(other.isRequired, isRequired) &&
-            const DeepCollectionEquality().equals(other.isNamed, isNamed) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
-            const DeepCollectionEquality().equals(other.typeName, typeName));
+            (identical(other.isRequired, isRequired) ||
+                other.isRequired == isRequired) &&
+            (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(isRequired),
-      const DeepCollectionEquality().hash(isNamed),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
-      const DeepCollectionEquality().hash(typeName));
+      runtimeType, isRequired, isNamed, name, isDeprecated, typeName);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ExecutableParameterDeclarationCopyWith<_$_ExecutableParameterDeclaration>
       get copyWith => __$$_ExecutableParameterDeclarationCopyWithImpl<
           _$_ExecutableParameterDeclaration>(this, _$identity);
@@ -278,7 +279,8 @@ mixin _$ExecutableDeclaration {
 abstract class $ExecutableDeclarationCopyWith<$Res> {
   factory $ExecutableDeclarationCopyWith(ExecutableDeclaration value,
           $Res Function(ExecutableDeclaration) then) =
-      _$ExecutableDeclarationCopyWithImpl<$Res>;
+      _$ExecutableDeclarationCopyWithImpl<$Res, ExecutableDeclaration>;
+  @useResult
   $Res call(
       {String returnTypeName,
       String name,
@@ -291,59 +293,62 @@ abstract class $ExecutableDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableDeclarationCopyWithImpl<$Res>
+class _$ExecutableDeclarationCopyWithImpl<$Res,
+        $Val extends ExecutableDeclaration>
     implements $ExecutableDeclarationCopyWith<$Res> {
   _$ExecutableDeclarationCopyWithImpl(this._value, this._then);
 
-  final ExecutableDeclaration _value;
   // ignore: unused_field
-  final $Res Function(ExecutableDeclaration) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? returnTypeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? parameters = freezed,
-    Object? typeParameterNames = freezed,
-    Object? type = freezed,
-    Object? isStatic = freezed,
+    Object? returnTypeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? parameters = null,
+    Object? typeParameterNames = null,
+    Object? type = null,
+    Object? isStatic = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      returnTypeName: returnTypeName == freezed
+      returnTypeName: null == returnTypeName
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: parameters == freezed
+      parameters: null == parameters
           ? _value.parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclaration>,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: type == freezed
+      type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableType,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -354,6 +359,7 @@ abstract class _$$_ExecutableDeclarationCopyWith<$Res>
           $Res Function(_$_ExecutableDeclaration) then) =
       __$$_ExecutableDeclarationCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String returnTypeName,
       String name,
@@ -367,57 +373,54 @@ abstract class _$$_ExecutableDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableDeclarationCopyWithImpl<$Res>
-    extends _$ExecutableDeclarationCopyWithImpl<$Res>
+    extends _$ExecutableDeclarationCopyWithImpl<$Res, _$_ExecutableDeclaration>
     implements _$$_ExecutableDeclarationCopyWith<$Res> {
   __$$_ExecutableDeclarationCopyWithImpl(_$_ExecutableDeclaration _value,
       $Res Function(_$_ExecutableDeclaration) _then)
-      : super(_value, (v) => _then(v as _$_ExecutableDeclaration));
+      : super(_value, _then);
 
-  @override
-  _$_ExecutableDeclaration get _value =>
-      super._value as _$_ExecutableDeclaration;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? returnTypeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? parameters = freezed,
-    Object? typeParameterNames = freezed,
-    Object? type = freezed,
-    Object? isStatic = freezed,
+    Object? returnTypeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? parameters = null,
+    Object? typeParameterNames = null,
+    Object? type = null,
+    Object? isStatic = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_ExecutableDeclaration(
-      returnTypeName: returnTypeName == freezed
+      returnTypeName: null == returnTypeName
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: parameters == freezed
+      parameters: null == parameters
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclaration>,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: type == freezed
+      type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableType,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -485,17 +488,18 @@ class _$_ExecutableDeclaration extends _ExecutableDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableDeclaration &&
-            const DeepCollectionEquality()
-                .equals(other.returnTypeName, returnTypeName) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.returnTypeName, returnTypeName) ||
+                other.returnTypeName == returnTypeName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
-            const DeepCollectionEquality().equals(other.type, type) &&
-            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
@@ -503,17 +507,18 @@ class _$_ExecutableDeclaration extends _ExecutableDeclaration {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(returnTypeName),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
+      returnTypeName,
+      name,
+      isDeprecated,
       const DeepCollectionEquality().hash(_parameters),
       const DeepCollectionEquality().hash(_typeParameterNames),
-      const DeepCollectionEquality().hash(type),
-      const DeepCollectionEquality().hash(isStatic),
+      type,
+      isStatic,
       const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ExecutableDeclarationCopyWith<_$_ExecutableDeclaration> get copyWith =>
       __$$_ExecutableDeclarationCopyWithImpl<_$_ExecutableDeclaration>(
           this, _$identity);

--- a/lib/src/model/field_declaration.freezed.dart
+++ b/lib/src/model/field_declaration.freezed.dart
@@ -31,8 +31,7 @@ mixin _$FieldDeclaration {
 abstract class $FieldDeclarationCopyWith<$Res> {
   factory $FieldDeclarationCopyWith(
           FieldDeclaration value, $Res Function(FieldDeclaration) then) =
-      _$FieldDeclarationCopyWithImpl<$Res, FieldDeclaration>;
-  @useResult
+      _$FieldDeclarationCopyWithImpl<$Res>;
   $Res call(
       {String typeName,
       String name,
@@ -42,46 +41,44 @@ abstract class $FieldDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$FieldDeclarationCopyWithImpl<$Res, $Val extends FieldDeclaration>
+class _$FieldDeclarationCopyWithImpl<$Res>
     implements $FieldDeclarationCopyWith<$Res> {
   _$FieldDeclarationCopyWithImpl(this._value, this._then);
 
+  final FieldDeclaration _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(FieldDeclaration) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? typeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isStatic = null,
+    Object? typeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? isStatic = freezed,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ) as $Val);
+    ));
   }
 }
 
@@ -92,7 +89,6 @@ abstract class _$$_FieldDeclarationCopyWith<$Res>
           _$_FieldDeclaration value, $Res Function(_$_FieldDeclaration) then) =
       __$$_FieldDeclarationCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String typeName,
       String name,
@@ -103,39 +99,41 @@ abstract class _$$_FieldDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_FieldDeclarationCopyWithImpl<$Res>
-    extends _$FieldDeclarationCopyWithImpl<$Res, _$_FieldDeclaration>
+    extends _$FieldDeclarationCopyWithImpl<$Res>
     implements _$$_FieldDeclarationCopyWith<$Res> {
   __$$_FieldDeclarationCopyWithImpl(
       _$_FieldDeclaration _value, $Res Function(_$_FieldDeclaration) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_FieldDeclaration));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_FieldDeclaration get _value => super._value as _$_FieldDeclaration;
+
   @override
   $Res call({
-    Object? typeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isStatic = null,
+    Object? typeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? isStatic = freezed,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_FieldDeclaration(
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -182,24 +180,26 @@ class _$_FieldDeclaration extends _FieldDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_FieldDeclaration &&
-            (identical(other.typeName, typeName) ||
-                other.typeName == typeName) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
-            (identical(other.isStatic, isStatic) ||
-                other.isStatic == isStatic) &&
+            const DeepCollectionEquality().equals(other.typeName, typeName) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
+            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, typeName, name, isDeprecated,
-      isStatic, const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(typeName),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
+      const DeepCollectionEquality().hash(isStatic),
+      const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_FieldDeclarationCopyWith<_$_FieldDeclaration> get copyWith =>
       __$$_FieldDeclarationCopyWithImpl<_$_FieldDeclaration>(this, _$identity);
 }

--- a/lib/src/model/field_declaration.freezed.dart
+++ b/lib/src/model/field_declaration.freezed.dart
@@ -31,7 +31,8 @@ mixin _$FieldDeclaration {
 abstract class $FieldDeclarationCopyWith<$Res> {
   factory $FieldDeclarationCopyWith(
           FieldDeclaration value, $Res Function(FieldDeclaration) then) =
-      _$FieldDeclarationCopyWithImpl<$Res>;
+      _$FieldDeclarationCopyWithImpl<$Res, FieldDeclaration>;
+  @useResult
   $Res call(
       {String typeName,
       String name,
@@ -41,44 +42,46 @@ abstract class $FieldDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$FieldDeclarationCopyWithImpl<$Res>
+class _$FieldDeclarationCopyWithImpl<$Res, $Val extends FieldDeclaration>
     implements $FieldDeclarationCopyWith<$Res> {
   _$FieldDeclarationCopyWithImpl(this._value, this._then);
 
-  final FieldDeclaration _value;
   // ignore: unused_field
-  final $Res Function(FieldDeclaration) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? typeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? isStatic = freezed,
+    Object? typeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isStatic = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -89,6 +92,7 @@ abstract class _$$_FieldDeclarationCopyWith<$Res>
           _$_FieldDeclaration value, $Res Function(_$_FieldDeclaration) then) =
       __$$_FieldDeclarationCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String typeName,
       String name,
@@ -99,41 +103,39 @@ abstract class _$$_FieldDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_FieldDeclarationCopyWithImpl<$Res>
-    extends _$FieldDeclarationCopyWithImpl<$Res>
+    extends _$FieldDeclarationCopyWithImpl<$Res, _$_FieldDeclaration>
     implements _$$_FieldDeclarationCopyWith<$Res> {
   __$$_FieldDeclarationCopyWithImpl(
       _$_FieldDeclaration _value, $Res Function(_$_FieldDeclaration) _then)
-      : super(_value, (v) => _then(v as _$_FieldDeclaration));
+      : super(_value, _then);
 
-  @override
-  _$_FieldDeclaration get _value => super._value as _$_FieldDeclaration;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? typeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? isStatic = freezed,
+    Object? typeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isStatic = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_FieldDeclaration(
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -180,26 +182,24 @@ class _$_FieldDeclaration extends _FieldDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_FieldDeclaration &&
-            const DeepCollectionEquality().equals(other.typeName, typeName) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
-            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(typeName),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
-      const DeepCollectionEquality().hash(isStatic),
-      const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(runtimeType, typeName, name, isDeprecated,
+      isStatic, const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_FieldDeclarationCopyWith<_$_FieldDeclaration> get copyWith =>
       __$$_FieldDeclarationCopyWithImpl<_$_FieldDeclaration>(this, _$identity);
 }

--- a/lib/src/model/interface_declaration.dart
+++ b/lib/src/model/interface_declaration.dart
@@ -7,19 +7,19 @@ import 'declaration.dart';
 import 'executable_declaration.dart';
 import 'field_declaration.dart';
 
-part 'class_declaration.freezed.dart';
+part 'interface_declaration.freezed.dart';
 
 /// Represents a found class declaration
 @freezed
-class ClassDeclaration with _$ClassDeclaration implements Declaration {
+class InterfaceDeclaration with _$InterfaceDeclaration implements Declaration {
   /// the signature of this class condensed to one String
   /// contains Type arguments as well as base classes or implemented interfaces
   String get signature => _computeSignature();
 
-  const ClassDeclaration._();
+  const InterfaceDeclaration._();
 
   @Implements<Declaration>()
-  const factory ClassDeclaration({
+  const factory InterfaceDeclaration({
     required String name,
     required bool isDeprecated,
     required List<String> typeParameterNames,
@@ -27,7 +27,7 @@ class ClassDeclaration with _$ClassDeclaration implements Declaration {
     required List<ExecutableDeclaration> executableDeclarations,
     required List<FieldDeclaration> fieldDeclarations,
     Set<String>? entryPoints,
-  }) = _ClassDeclaration;
+  }) = _InterfaceDeclaration;
 
   String _computeSignature() {
     String superTypeSuffix = '';

--- a/lib/src/model/interface_declaration.freezed.dart
+++ b/lib/src/model/interface_declaration.freezed.dart
@@ -3,7 +3,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
-part of 'class_declaration.dart';
+part of 'interface_declaration.dart';
 
 // **************************************************************************
 // FreezedGenerator
@@ -15,7 +15,7 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
-mixin _$ClassDeclaration {
+mixin _$InterfaceDeclaration {
   String get name => throw _privateConstructorUsedError;
   bool get isDeprecated => throw _privateConstructorUsedError;
   List<String> get typeParameterNames => throw _privateConstructorUsedError;
@@ -27,16 +27,15 @@ mixin _$ClassDeclaration {
   Set<String>? get entryPoints => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
-  $ClassDeclarationCopyWith<ClassDeclaration> get copyWith =>
+  $InterfaceDeclarationCopyWith<InterfaceDeclaration> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $ClassDeclarationCopyWith<$Res> {
-  factory $ClassDeclarationCopyWith(
-          ClassDeclaration value, $Res Function(ClassDeclaration) then) =
-      _$ClassDeclarationCopyWithImpl<$Res, ClassDeclaration>;
-  @useResult
+abstract class $InterfaceDeclarationCopyWith<$Res> {
+  factory $InterfaceDeclarationCopyWith(InterfaceDeclaration value,
+          $Res Function(InterfaceDeclaration) then) =
+      _$InterfaceDeclarationCopyWithImpl<$Res>;
   $Res call(
       {String name,
       bool isDeprecated,
@@ -48,67 +47,64 @@ abstract class $ClassDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ClassDeclarationCopyWithImpl<$Res, $Val extends ClassDeclaration>
-    implements $ClassDeclarationCopyWith<$Res> {
-  _$ClassDeclarationCopyWithImpl(this._value, this._then);
+class _$InterfaceDeclarationCopyWithImpl<$Res>
+    implements $InterfaceDeclarationCopyWith<$Res> {
+  _$InterfaceDeclarationCopyWithImpl(this._value, this._then);
 
+  final InterfaceDeclaration _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(InterfaceDeclaration) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeParameterNames = null,
-    Object? superTypeNames = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeParameterNames = freezed,
+    Object? superTypeNames = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: null == superTypeNames
+      superTypeNames: superTypeNames == freezed
           ? _value.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: null == executableDeclarations
+      executableDeclarations: executableDeclarations == freezed
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ) as $Val);
+    ));
   }
 }
 
 /// @nodoc
-abstract class _$$_ClassDeclarationCopyWith<$Res>
-    implements $ClassDeclarationCopyWith<$Res> {
-  factory _$$_ClassDeclarationCopyWith(
-          _$_ClassDeclaration value, $Res Function(_$_ClassDeclaration) then) =
-      __$$_ClassDeclarationCopyWithImpl<$Res>;
+abstract class _$$_InterfaceDeclarationCopyWith<$Res>
+    implements $InterfaceDeclarationCopyWith<$Res> {
+  factory _$$_InterfaceDeclarationCopyWith(_$_InterfaceDeclaration value,
+          $Res Function(_$_InterfaceDeclaration) then) =
+      __$$_InterfaceDeclarationCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -120,50 +116,52 @@ abstract class _$$_ClassDeclarationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ClassDeclarationCopyWithImpl<$Res>
-    extends _$ClassDeclarationCopyWithImpl<$Res, _$_ClassDeclaration>
-    implements _$$_ClassDeclarationCopyWith<$Res> {
-  __$$_ClassDeclarationCopyWithImpl(
-      _$_ClassDeclaration _value, $Res Function(_$_ClassDeclaration) _then)
-      : super(_value, _then);
+class __$$_InterfaceDeclarationCopyWithImpl<$Res>
+    extends _$InterfaceDeclarationCopyWithImpl<$Res>
+    implements _$$_InterfaceDeclarationCopyWith<$Res> {
+  __$$_InterfaceDeclarationCopyWithImpl(_$_InterfaceDeclaration _value,
+      $Res Function(_$_InterfaceDeclaration) _then)
+      : super(_value, (v) => _then(v as _$_InterfaceDeclaration));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_InterfaceDeclaration get _value => super._value as _$_InterfaceDeclaration;
+
   @override
   $Res call({
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeParameterNames = null,
-    Object? superTypeNames = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeParameterNames = freezed,
+    Object? superTypeNames = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
     Object? entryPoints = freezed,
   }) {
-    return _then(_$_ClassDeclaration(
-      name: null == name
+    return _then(_$_InterfaceDeclaration(
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: null == superTypeNames
+      superTypeNames: superTypeNames == freezed
           ? _value._superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: null == executableDeclarations
+      executableDeclarations: executableDeclarations == freezed
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -173,8 +171,8 @@ class __$$_ClassDeclarationCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_ClassDeclaration extends _ClassDeclaration {
-  const _$_ClassDeclaration(
+class _$_InterfaceDeclaration extends _InterfaceDeclaration {
+  const _$_InterfaceDeclaration(
       {required this.name,
       required this.isDeprecated,
       required final List<String> typeParameterNames,
@@ -232,17 +230,17 @@ class _$_ClassDeclaration extends _ClassDeclaration {
 
   @override
   String toString() {
-    return 'ClassDeclaration(name: $name, isDeprecated: $isDeprecated, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
+    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ClassDeclaration &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
+            other is _$_InterfaceDeclaration &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -258,8 +256,8 @@ class _$_ClassDeclaration extends _ClassDeclaration {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      name,
-      isDeprecated,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -268,22 +266,22 @@ class _$_ClassDeclaration extends _ClassDeclaration {
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
-  _$$_ClassDeclarationCopyWith<_$_ClassDeclaration> get copyWith =>
-      __$$_ClassDeclarationCopyWithImpl<_$_ClassDeclaration>(this, _$identity);
+  _$$_InterfaceDeclarationCopyWith<_$_InterfaceDeclaration> get copyWith =>
+      __$$_InterfaceDeclarationCopyWithImpl<_$_InterfaceDeclaration>(
+          this, _$identity);
 }
 
-abstract class _ClassDeclaration extends ClassDeclaration
+abstract class _InterfaceDeclaration extends InterfaceDeclaration
     implements Declaration {
-  const factory _ClassDeclaration(
+  const factory _InterfaceDeclaration(
       {required final String name,
       required final bool isDeprecated,
       required final List<String> typeParameterNames,
       required final List<String> superTypeNames,
       required final List<ExecutableDeclaration> executableDeclarations,
       required final List<FieldDeclaration> fieldDeclarations,
-      final Set<String>? entryPoints}) = _$_ClassDeclaration;
-  const _ClassDeclaration._() : super._();
+      final Set<String>? entryPoints}) = _$_InterfaceDeclaration;
+  const _InterfaceDeclaration._() : super._();
 
   @override
   String get name;
@@ -301,6 +299,6 @@ abstract class _ClassDeclaration extends ClassDeclaration
   Set<String>? get entryPoints;
   @override
   @JsonKey(ignore: true)
-  _$$_ClassDeclarationCopyWith<_$_ClassDeclaration> get copyWith =>
+  _$$_InterfaceDeclarationCopyWith<_$_InterfaceDeclaration> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/model/interface_declaration.freezed.dart
+++ b/lib/src/model/interface_declaration.freezed.dart
@@ -35,7 +35,8 @@ mixin _$InterfaceDeclaration {
 abstract class $InterfaceDeclarationCopyWith<$Res> {
   factory $InterfaceDeclarationCopyWith(InterfaceDeclaration value,
           $Res Function(InterfaceDeclaration) then) =
-      _$InterfaceDeclarationCopyWithImpl<$Res>;
+      _$InterfaceDeclarationCopyWithImpl<$Res, InterfaceDeclaration>;
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -47,54 +48,57 @@ abstract class $InterfaceDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$InterfaceDeclarationCopyWithImpl<$Res>
+class _$InterfaceDeclarationCopyWithImpl<$Res,
+        $Val extends InterfaceDeclaration>
     implements $InterfaceDeclarationCopyWith<$Res> {
   _$InterfaceDeclarationCopyWithImpl(this._value, this._then);
 
-  final InterfaceDeclaration _value;
   // ignore: unused_field
-  final $Res Function(InterfaceDeclaration) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -105,6 +109,7 @@ abstract class _$$_InterfaceDeclarationCopyWith<$Res>
           $Res Function(_$_InterfaceDeclaration) then) =
       __$$_InterfaceDeclarationCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -117,51 +122,49 @@ abstract class _$$_InterfaceDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_InterfaceDeclarationCopyWithImpl<$Res>
-    extends _$InterfaceDeclarationCopyWithImpl<$Res>
+    extends _$InterfaceDeclarationCopyWithImpl<$Res, _$_InterfaceDeclaration>
     implements _$$_InterfaceDeclarationCopyWith<$Res> {
   __$$_InterfaceDeclarationCopyWithImpl(_$_InterfaceDeclaration _value,
       $Res Function(_$_InterfaceDeclaration) _then)
-      : super(_value, (v) => _then(v as _$_InterfaceDeclaration));
+      : super(_value, _then);
 
-  @override
-  _$_InterfaceDeclaration get _value => super._value as _$_InterfaceDeclaration;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_InterfaceDeclaration(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value._superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -238,9 +241,9 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_InterfaceDeclaration &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -256,8 +259,8 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
+      name,
+      isDeprecated,
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -266,6 +269,7 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_InterfaceDeclarationCopyWith<_$_InterfaceDeclaration> get copyWith =>
       __$$_InterfaceDeclarationCopyWithImpl<_$_InterfaceDeclaration>(
           this, _$identity);

--- a/lib/src/model/internal/internal_class_declaration.dart
+++ b/lib/src/model/internal/internal_class_declaration.dart
@@ -65,6 +65,26 @@ class InternalClassDeclaration implements InternalDeclaration {
               .toList(),
         );
 
+  InternalClassDeclaration.fromExtensionElement(
+      ExtensionElement extensionElement,
+      {String? namespace})
+      : this._(
+          id: InternalDeclarationUtils.getIdFromElement(extensionElement)!,
+          parentClassId: InternalDeclarationUtils.getIdFromElement(
+              extensionElement.enclosingElement3),
+          name: extensionElement.name ?? extensionElement.displayName,
+          namespace: namespace,
+          isPrivate: extensionElement.isPrivate,
+          isDeprecated: extensionElement.hasDeprecated,
+          typeParameterNames: InternalDeclarationUtils.computeTypeParameters(
+              extensionElement.typeParameters),
+          superTypeNames: const [],
+          executableDeclarations: [],
+          fieldDeclarations: [],
+          entryPoints: {},
+          superClassIds: [],
+        );
+
   ClassDeclaration toClassDeclaration() {
     final namespacePrefix = namespace == null ? '' : '$namespace.';
     return ClassDeclaration(

--- a/lib/src/model/internal/internal_class_declaration.dart
+++ b/lib/src/model/internal/internal_class_declaration.dart
@@ -42,24 +42,25 @@ class InternalClassDeclaration implements InternalDeclaration {
     required this.superClassIds,
   });
 
-  InternalClassDeclaration.fromClassElement(ClassElement classElement,
+  InternalClassDeclaration.fromInterfaceElement(
+      InterfaceElement interfaceElement,
       {String? namespace})
       : this._(
-          id: InternalDeclarationUtils.getIdFromElement(classElement)!,
-          parentClassId: InternalDeclarationUtils.getIdFromElement(
-              classElement.enclosingElement3),
-          name: classElement.name,
+          id: InternalDeclarationUtils.getIdFromElement(interfaceElement)!,
+          parentClassId: InternalDeclarationUtils.getIdFromParentElement(
+              interfaceElement.enclosingElement3),
+          name: interfaceElement.name,
           namespace: namespace,
-          isPrivate: classElement.isPrivate,
-          isDeprecated: classElement.hasDeprecated,
+          isPrivate: interfaceElement.isPrivate,
+          isDeprecated: interfaceElement.hasDeprecated,
           typeParameterNames: InternalDeclarationUtils.computeTypeParameters(
-              classElement.typeParameters),
+              interfaceElement.typeParameters),
           superTypeNames: InternalDeclarationUtils.computeSuperTypeNames(
-              classElement.allSupertypes),
+              interfaceElement.allSupertypes),
           executableDeclarations: [],
           fieldDeclarations: [],
           entryPoints: {},
-          superClassIds: classElement.allSupertypes
+          superClassIds: interfaceElement.allSupertypes
               .map((e) => InternalDeclarationUtils.getIdFromElement(e.element2))
               .whereNotNull()
               .toList(),
@@ -70,7 +71,7 @@ class InternalClassDeclaration implements InternalDeclaration {
       {String? namespace})
       : this._(
           id: InternalDeclarationUtils.getIdFromElement(extensionElement)!,
-          parentClassId: InternalDeclarationUtils.getIdFromElement(
+          parentClassId: InternalDeclarationUtils.getIdFromParentElement(
               extensionElement.enclosingElement3),
           name: extensionElement.name ?? extensionElement.displayName,
           namespace: namespace,

--- a/lib/src/model/internal/internal_declaration_utils.dart
+++ b/lib/src/model/internal/internal_declaration_utils.dart
@@ -9,6 +9,13 @@ abstract class InternalDeclarationUtils {
     return element.id;
   }
 
+  static int? getIdFromParentElement(Element? element) {
+    if (element is InterfaceElement || element is ExtensionElement) {
+      return getIdFromElement(element);
+    }
+    return null;
+  }
+
   static List<String> computeTypeParameters(
       List<TypeParameterElement> typeParameters) {
     return typeParameters.map((e) => e.name).toList();

--- a/lib/src/model/internal/internal_executable_declaration.dart
+++ b/lib/src/model/internal/internal_executable_declaration.dart
@@ -41,12 +41,8 @@ class InternalExecutableDeclaration implements InternalDeclaration {
       {String? namespace})
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(executableElement)!,
-            parentClassId:
-                executableElement.enclosingElement3 is ClassElement ||
-                        executableElement.enclosingElement3 is ExtensionElement
-                    ? InternalDeclarationUtils.getIdFromElement(
-                        executableElement.enclosingElement3)
-                    : null,
+            parentClassId: InternalDeclarationUtils.getIdFromParentElement(
+                executableElement.enclosingElement3),
             returnTypeName: executableElement.returnType
                 .getDisplayString(withNullability: true),
             name: executableElement.displayName,

--- a/lib/src/model/internal/internal_executable_declaration.dart
+++ b/lib/src/model/internal/internal_executable_declaration.dart
@@ -41,10 +41,12 @@ class InternalExecutableDeclaration implements InternalDeclaration {
       {String? namespace})
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(executableElement)!,
-            parentClassId: executableElement.enclosingElement3 is ClassElement
-                ? InternalDeclarationUtils.getIdFromElement(
-                    executableElement.enclosingElement3)
-                : null,
+            parentClassId:
+                executableElement.enclosingElement3 is ClassElement ||
+                        executableElement.enclosingElement3 is ExtensionElement
+                    ? InternalDeclarationUtils.getIdFromElement(
+                        executableElement.enclosingElement3)
+                    : null,
             returnTypeName: executableElement.returnType
                 .getDisplayString(withNullability: true),
             name: executableElement.displayName,

--- a/lib/src/model/internal/internal_field_declaration.dart
+++ b/lib/src/model/internal/internal_field_declaration.dart
@@ -35,11 +35,8 @@ class InternalFieldDeclaration implements InternalDeclaration {
       {String? namespace})
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(fieldElement)!,
-            parentClassId: (fieldElement.enclosingElement3 is ClassElement ||
-                    fieldElement.enclosingElement3 is ExtensionElement)
-                ? InternalDeclarationUtils.getIdFromElement(
-                    fieldElement.enclosingElement3)
-                : null,
+            parentClassId: InternalDeclarationUtils.getIdFromParentElement(
+                fieldElement.enclosingElement3),
             typeName: fieldElement.type.getDisplayString(withNullability: true),
             name: fieldElement.name,
             namespace: namespace,

--- a/lib/src/model/internal/internal_field_declaration.dart
+++ b/lib/src/model/internal/internal_field_declaration.dart
@@ -35,7 +35,8 @@ class InternalFieldDeclaration implements InternalDeclaration {
       {String? namespace})
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(fieldElement)!,
-            parentClassId: fieldElement.enclosingElement3 is ClassElement
+            parentClassId: (fieldElement.enclosingElement3 is ClassElement ||
+                    fieldElement.enclosingElement3 is ExtensionElement)
                 ? InternalDeclarationUtils.getIdFromElement(
                     fieldElement.enclosingElement3)
                 : null,

--- a/lib/src/model/internal/internal_interface_declaration.dart
+++ b/lib/src/model/internal/internal_interface_declaration.dart
@@ -1,14 +1,14 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 
-import '../class_declaration.dart';
+import '../interface_declaration.dart';
 import '../executable_declaration.dart';
 import '../field_declaration.dart';
 import 'internal_declaration.dart';
 import 'internal_declaration_utils.dart';
 
-/// Internal extension of [ClassDeclaration] that adds the [id] and [parentClassId] that is not stable between runs
-class InternalClassDeclaration implements InternalDeclaration {
+/// Internal extension of [InterfaceDeclaration] that adds the [id] and [parentClassId] that is not stable between runs
+class InternalInterfaceDeclaration implements InternalDeclaration {
   @override
   final int id;
   @override
@@ -27,7 +27,7 @@ class InternalClassDeclaration implements InternalDeclaration {
   final Set<String>? entryPoints;
   final List<int> superClassIds;
 
-  InternalClassDeclaration._({
+  InternalInterfaceDeclaration._({
     required this.id,
     this.parentClassId,
     required this.name,
@@ -42,7 +42,7 @@ class InternalClassDeclaration implements InternalDeclaration {
     required this.superClassIds,
   });
 
-  InternalClassDeclaration.fromInterfaceElement(
+  InternalInterfaceDeclaration.fromInterfaceElement(
       InterfaceElement interfaceElement,
       {String? namespace})
       : this._(
@@ -66,7 +66,7 @@ class InternalClassDeclaration implements InternalDeclaration {
               .toList(),
         );
 
-  InternalClassDeclaration.fromExtensionElement(
+  InternalInterfaceDeclaration.fromExtensionElement(
       ExtensionElement extensionElement,
       {String? namespace})
       : this._(
@@ -86,9 +86,9 @@ class InternalClassDeclaration implements InternalDeclaration {
           superClassIds: [],
         );
 
-  ClassDeclaration toClassDeclaration() {
+  InterfaceDeclaration toInterfaceDeclaration() {
     final namespacePrefix = namespace == null ? '' : '$namespace.';
-    return ClassDeclaration(
+    return InterfaceDeclaration(
       name: '$namespacePrefix$name',
       isDeprecated: isDeprecated,
       typeParameterNames: typeParameterNames,

--- a/lib/src/model/internal/internal_type_alias_declaration.dart
+++ b/lib/src/model/internal/internal_type_alias_declaration.dart
@@ -33,7 +33,8 @@ class InternalTypeAliasDeclaration implements InternalDeclaration {
       {String? namespace})
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(typeAliasElement)!,
-            parentClassId: typeAliasElement.enclosingElement3 is ClassElement
+            parentClassId: typeAliasElement.enclosingElement3 is ClassElement ||
+                    typeAliasElement.enclosingElement3 is ExtensionElement
                 ? InternalDeclarationUtils.getIdFromElement(
                     typeAliasElement.enclosingElement3)
                 : null,

--- a/lib/src/model/internal/internal_type_alias_declaration.dart
+++ b/lib/src/model/internal/internal_type_alias_declaration.dart
@@ -33,11 +33,8 @@ class InternalTypeAliasDeclaration implements InternalDeclaration {
       {String? namespace})
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(typeAliasElement)!,
-            parentClassId: typeAliasElement.enclosingElement3 is ClassElement ||
-                    typeAliasElement.enclosingElement3 is ExtensionElement
-                ? InternalDeclarationUtils.getIdFromElement(
-                    typeAliasElement.enclosingElement3)
-                : null,
+            parentClassId: InternalDeclarationUtils.getIdFromParentElement(
+                typeAliasElement.enclosingElement3),
             name: typeAliasElement.name,
             namespace: namespace,
             aliasedTypeName: typeAliasElement.aliasedType

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -1,6 +1,6 @@
 export 'declaration.dart';
 export 'package_api.dart';
-export 'class_declaration.dart';
+export 'interface_declaration.dart';
 export 'executable_declaration.dart';
 export 'field_declaration.dart';
 export 'type_alias_declaration.dart';

--- a/lib/src/model/package_api.dart
+++ b/lib/src/model/package_api.dart
@@ -3,7 +3,7 @@ import 'package:dart_apitool/src/model/type_alias_declaration.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pub_semver/pub_semver.dart';
 
-import 'class_declaration.dart';
+import 'interface_declaration.dart';
 import 'executable_declaration.dart';
 import 'field_declaration.dart';
 import 'package_api_semantics.dart';
@@ -26,8 +26,8 @@ class PackageApi with _$PackageApi {
     /// path to the package
     required String packagePath,
 
-    /// class declarations this package has
-    required List<ClassDeclaration> classDeclarations,
+    /// interface declarations this package has
+    required List<InterfaceDeclaration> interfaceDeclarations,
 
     /// root level executable declarations this package has
     required List<ExecutableDeclaration> executableDeclarations,

--- a/lib/src/model/package_api.freezed.dart
+++ b/lib/src/model/package_api.freezed.dart
@@ -67,7 +67,8 @@ mixin _$PackageApi {
 abstract class $PackageApiCopyWith<$Res> {
   factory $PackageApiCopyWith(
           PackageApi value, $Res Function(PackageApi) then) =
-      _$PackageApiCopyWithImpl<$Res>;
+      _$PackageApiCopyWithImpl<$Res, PackageApi>;
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -87,81 +88,85 @@ abstract class $PackageApiCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
+class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
+    implements $PackageApiCopyWith<$Res> {
   _$PackageApiCopyWithImpl(this._value, this._then);
 
-  final PackageApi _value;
   // ignore: unused_field
-  final $Res Function(PackageApi) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? interfaceDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? interfaceDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? androidPlatformConstraints = freezed,
     Object? iosPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_value.copyWith(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      interfaceDeclarations: interfaceDeclarations == freezed
+      interfaceDeclarations: null == interfaceDeclarations
           ? _value.interfaceDeclarations
           : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
               as List<InterfaceDeclaration>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclaration>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraints?,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraints?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkType,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsCopyWith<$Res>? get androidPlatformConstraints {
     if (_value.androidPlatformConstraints == null) {
       return null;
@@ -169,11 +174,12 @@ class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
 
     return $AndroidPlatformConstraintsCopyWith<$Res>(
         _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value));
+      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsCopyWith<$Res>? get iosPlatformConstraints {
     if (_value.iosPlatformConstraints == null) {
       return null;
@@ -181,7 +187,7 @@ class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
 
     return $IOSPlatformConstraintsCopyWith<$Res>(_value.iosPlatformConstraints!,
         (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value));
+      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
     });
   }
 }
@@ -193,6 +199,7 @@ abstract class _$$_PackageApiCopyWith<$Res>
           _$_PackageApi value, $Res Function(_$_PackageApi) then) =
       __$$_PackageApiCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -214,76 +221,75 @@ abstract class _$$_PackageApiCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PackageApiCopyWithImpl<$Res> extends _$PackageApiCopyWithImpl<$Res>
+class __$$_PackageApiCopyWithImpl<$Res>
+    extends _$PackageApiCopyWithImpl<$Res, _$_PackageApi>
     implements _$$_PackageApiCopyWith<$Res> {
   __$$_PackageApiCopyWithImpl(
       _$_PackageApi _value, $Res Function(_$_PackageApi) _then)
-      : super(_value, (v) => _then(v as _$_PackageApi));
+      : super(_value, _then);
 
-  @override
-  _$_PackageApi get _value => super._value as _$_PackageApi;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? interfaceDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? interfaceDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? androidPlatformConstraints = freezed,
     Object? iosPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_$_PackageApi(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      interfaceDeclarations: interfaceDeclarations == freezed
+      interfaceDeclarations: null == interfaceDeclarations
           ? _value._interfaceDeclarations
           : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
               as List<InterfaceDeclaration>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value._typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclaration>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value._semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraints?,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraints?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkType,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
@@ -403,12 +409,12 @@ class _$_PackageApi extends _PackageApi {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PackageApi &&
-            const DeepCollectionEquality()
-                .equals(other.packageName, packageName) &&
-            const DeepCollectionEquality()
-                .equals(other.packageVersion, packageVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.packagePath, packagePath) &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion) &&
+            (identical(other.packagePath, packagePath) ||
+                other.packagePath == packagePath) &&
             const DeepCollectionEquality()
                 .equals(other._interfaceDeclarations, _interfaceDeclarations) &&
             const DeepCollectionEquality().equals(
@@ -419,33 +425,36 @@ class _$_PackageApi extends _PackageApi {
                 .equals(other._typeAliasDeclarations, _typeAliasDeclarations) &&
             const DeepCollectionEquality()
                 .equals(other._semantics, _semantics) &&
-            const DeepCollectionEquality().equals(
-                other.androidPlatformConstraints, androidPlatformConstraints) &&
-            const DeepCollectionEquality()
-                .equals(other.iosPlatformConstraints, iosPlatformConstraints) &&
-            const DeepCollectionEquality().equals(other.sdkType, sdkType) &&
-            const DeepCollectionEquality()
-                .equals(other.minSdkVersion, minSdkVersion));
+            (identical(other.androidPlatformConstraints,
+                    androidPlatformConstraints) ||
+                other.androidPlatformConstraints ==
+                    androidPlatformConstraints) &&
+            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
+                other.iosPlatformConstraints == iosPlatformConstraints) &&
+            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(packageName),
-      const DeepCollectionEquality().hash(packageVersion),
-      const DeepCollectionEquality().hash(packagePath),
+      packageName,
+      packageVersion,
+      packagePath,
       const DeepCollectionEquality().hash(_interfaceDeclarations),
       const DeepCollectionEquality().hash(_executableDeclarations),
       const DeepCollectionEquality().hash(_fieldDeclarations),
       const DeepCollectionEquality().hash(_typeAliasDeclarations),
       const DeepCollectionEquality().hash(_semantics),
-      const DeepCollectionEquality().hash(androidPlatformConstraints),
-      const DeepCollectionEquality().hash(iosPlatformConstraints),
-      const DeepCollectionEquality().hash(sdkType),
-      const DeepCollectionEquality().hash(minSdkVersion));
+      androidPlatformConstraints,
+      iosPlatformConstraints,
+      sdkType,
+      minSdkVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_PackageApiCopyWith<_$_PackageApi> get copyWith =>
       __$$_PackageApiCopyWithImpl<_$_PackageApi>(this, _$identity);
 }

--- a/lib/src/model/package_api.freezed.dart
+++ b/lib/src/model/package_api.freezed.dart
@@ -67,7 +67,8 @@ mixin _$PackageApi {
 abstract class $PackageApiCopyWith<$Res> {
   factory $PackageApiCopyWith(
           PackageApi value, $Res Function(PackageApi) then) =
-      _$PackageApiCopyWithImpl<$Res>;
+      _$PackageApiCopyWithImpl<$Res, PackageApi>;
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -87,81 +88,85 @@ abstract class $PackageApiCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
+class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
+    implements $PackageApiCopyWith<$Res> {
   _$PackageApiCopyWithImpl(this._value, this._then);
 
-  final PackageApi _value;
   // ignore: unused_field
-  final $Res Function(PackageApi) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? classDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? classDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? androidPlatformConstraints = freezed,
     Object? iosPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_value.copyWith(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: classDeclarations == freezed
+      classDeclarations: null == classDeclarations
           ? _value.classDeclarations
           : classDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ClassDeclaration>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclaration>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraints?,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraints?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkType,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsCopyWith<$Res>? get androidPlatformConstraints {
     if (_value.androidPlatformConstraints == null) {
       return null;
@@ -169,11 +174,12 @@ class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
 
     return $AndroidPlatformConstraintsCopyWith<$Res>(
         _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value));
+      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsCopyWith<$Res>? get iosPlatformConstraints {
     if (_value.iosPlatformConstraints == null) {
       return null;
@@ -181,7 +187,7 @@ class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
 
     return $IOSPlatformConstraintsCopyWith<$Res>(_value.iosPlatformConstraints!,
         (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value));
+      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
     });
   }
 }
@@ -193,6 +199,7 @@ abstract class _$$_PackageApiCopyWith<$Res>
           _$_PackageApi value, $Res Function(_$_PackageApi) then) =
       __$$_PackageApiCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -214,76 +221,75 @@ abstract class _$$_PackageApiCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PackageApiCopyWithImpl<$Res> extends _$PackageApiCopyWithImpl<$Res>
+class __$$_PackageApiCopyWithImpl<$Res>
+    extends _$PackageApiCopyWithImpl<$Res, _$_PackageApi>
     implements _$$_PackageApiCopyWith<$Res> {
   __$$_PackageApiCopyWithImpl(
       _$_PackageApi _value, $Res Function(_$_PackageApi) _then)
-      : super(_value, (v) => _then(v as _$_PackageApi));
+      : super(_value, _then);
 
-  @override
-  _$_PackageApi get _value => super._value as _$_PackageApi;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? classDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? classDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? androidPlatformConstraints = freezed,
     Object? iosPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_$_PackageApi(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: classDeclarations == freezed
+      classDeclarations: null == classDeclarations
           ? _value._classDeclarations
           : classDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ClassDeclaration>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value._typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclaration>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value._semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraints?,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraints?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkType,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
@@ -403,12 +409,12 @@ class _$_PackageApi extends _PackageApi {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PackageApi &&
-            const DeepCollectionEquality()
-                .equals(other.packageName, packageName) &&
-            const DeepCollectionEquality()
-                .equals(other.packageVersion, packageVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.packagePath, packagePath) &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion) &&
+            (identical(other.packagePath, packagePath) ||
+                other.packagePath == packagePath) &&
             const DeepCollectionEquality()
                 .equals(other._classDeclarations, _classDeclarations) &&
             const DeepCollectionEquality().equals(
@@ -419,33 +425,36 @@ class _$_PackageApi extends _PackageApi {
                 .equals(other._typeAliasDeclarations, _typeAliasDeclarations) &&
             const DeepCollectionEquality()
                 .equals(other._semantics, _semantics) &&
-            const DeepCollectionEquality().equals(
-                other.androidPlatformConstraints, androidPlatformConstraints) &&
-            const DeepCollectionEquality()
-                .equals(other.iosPlatformConstraints, iosPlatformConstraints) &&
-            const DeepCollectionEquality().equals(other.sdkType, sdkType) &&
-            const DeepCollectionEquality()
-                .equals(other.minSdkVersion, minSdkVersion));
+            (identical(other.androidPlatformConstraints,
+                    androidPlatformConstraints) ||
+                other.androidPlatformConstraints ==
+                    androidPlatformConstraints) &&
+            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
+                other.iosPlatformConstraints == iosPlatformConstraints) &&
+            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(packageName),
-      const DeepCollectionEquality().hash(packageVersion),
-      const DeepCollectionEquality().hash(packagePath),
+      packageName,
+      packageVersion,
+      packagePath,
       const DeepCollectionEquality().hash(_classDeclarations),
       const DeepCollectionEquality().hash(_executableDeclarations),
       const DeepCollectionEquality().hash(_fieldDeclarations),
       const DeepCollectionEquality().hash(_typeAliasDeclarations),
       const DeepCollectionEquality().hash(_semantics),
-      const DeepCollectionEquality().hash(androidPlatformConstraints),
-      const DeepCollectionEquality().hash(iosPlatformConstraints),
-      const DeepCollectionEquality().hash(sdkType),
-      const DeepCollectionEquality().hash(minSdkVersion));
+      androidPlatformConstraints,
+      iosPlatformConstraints,
+      sdkType,
+      minSdkVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_PackageApiCopyWith<_$_PackageApi> get copyWith =>
       __$$_PackageApiCopyWithImpl<_$_PackageApi>(this, _$identity);
 }

--- a/lib/src/model/package_api.freezed.dart
+++ b/lib/src/model/package_api.freezed.dart
@@ -25,8 +25,8 @@ mixin _$PackageApi {
   /// path to the package
   String get packagePath => throw _privateConstructorUsedError;
 
-  /// class declarations this package has
-  List<ClassDeclaration> get classDeclarations =>
+  /// interface declarations this package has
+  List<InterfaceDeclaration> get interfaceDeclarations =>
       throw _privateConstructorUsedError;
 
   /// root level executable declarations this package has
@@ -67,13 +67,12 @@ mixin _$PackageApi {
 abstract class $PackageApiCopyWith<$Res> {
   factory $PackageApiCopyWith(
           PackageApi value, $Res Function(PackageApi) then) =
-      _$PackageApiCopyWithImpl<$Res, PackageApi>;
-  @useResult
+      _$PackageApiCopyWithImpl<$Res>;
   $Res call(
       {String packageName,
       String? packageVersion,
       String packagePath,
-      List<ClassDeclaration> classDeclarations,
+      List<InterfaceDeclaration> interfaceDeclarations,
       List<ExecutableDeclaration> executableDeclarations,
       List<FieldDeclaration> fieldDeclarations,
       List<TypeAliasDeclaration> typeAliasDeclarations,
@@ -88,85 +87,81 @@ abstract class $PackageApiCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
-    implements $PackageApiCopyWith<$Res> {
+class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
   _$PackageApiCopyWithImpl(this._value, this._then);
 
+  final PackageApi _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(PackageApi) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = null,
+    Object? packageName = freezed,
     Object? packageVersion = freezed,
-    Object? packagePath = null,
-    Object? classDeclarations = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? typeAliasDeclarations = null,
-    Object? semantics = null,
+    Object? packagePath = freezed,
+    Object? interfaceDeclarations = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
+    Object? typeAliasDeclarations = freezed,
+    Object? semantics = freezed,
     Object? androidPlatformConstraints = freezed,
     Object? iosPlatformConstraints = freezed,
-    Object? sdkType = null,
-    Object? minSdkVersion = null,
+    Object? sdkType = freezed,
+    Object? minSdkVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      packageName: null == packageName
+      packageName: packageName == freezed
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: freezed == packageVersion
+      packageVersion: packageVersion == freezed
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: null == packagePath
+      packagePath: packagePath == freezed
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: null == classDeclarations
-          ? _value.classDeclarations
-          : classDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ClassDeclaration>,
-      executableDeclarations: null == executableDeclarations
+      interfaceDeclarations: interfaceDeclarations == freezed
+          ? _value.interfaceDeclarations
+          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<InterfaceDeclaration>,
+      executableDeclarations: executableDeclarations == freezed
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      typeAliasDeclarations: null == typeAliasDeclarations
+      typeAliasDeclarations: typeAliasDeclarations == freezed
           ? _value.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclaration>,
-      semantics: null == semantics
+      semantics: semantics == freezed
           ? _value.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      androidPlatformConstraints: freezed == androidPlatformConstraints
+      androidPlatformConstraints: androidPlatformConstraints == freezed
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraints?,
-      iosPlatformConstraints: freezed == iosPlatformConstraints
+      iosPlatformConstraints: iosPlatformConstraints == freezed
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraints?,
-      sdkType: null == sdkType
+      sdkType: sdkType == freezed
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkType,
-      minSdkVersion: null == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
-    ) as $Val);
+    ));
   }
 
   @override
-  @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsCopyWith<$Res>? get androidPlatformConstraints {
     if (_value.androidPlatformConstraints == null) {
       return null;
@@ -174,12 +169,11 @@ class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
 
     return $AndroidPlatformConstraintsCopyWith<$Res>(
         _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
+      return _then(_value.copyWith(androidPlatformConstraints: value));
     });
   }
 
   @override
-  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsCopyWith<$Res>? get iosPlatformConstraints {
     if (_value.iosPlatformConstraints == null) {
       return null;
@@ -187,7 +181,7 @@ class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
 
     return $IOSPlatformConstraintsCopyWith<$Res>(_value.iosPlatformConstraints!,
         (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
+      return _then(_value.copyWith(iosPlatformConstraints: value));
     });
   }
 }
@@ -199,12 +193,11 @@ abstract class _$$_PackageApiCopyWith<$Res>
           _$_PackageApi value, $Res Function(_$_PackageApi) then) =
       __$$_PackageApiCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
       String packagePath,
-      List<ClassDeclaration> classDeclarations,
+      List<InterfaceDeclaration> interfaceDeclarations,
       List<ExecutableDeclaration> executableDeclarations,
       List<FieldDeclaration> fieldDeclarations,
       List<TypeAliasDeclaration> typeAliasDeclarations,
@@ -221,75 +214,76 @@ abstract class _$$_PackageApiCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PackageApiCopyWithImpl<$Res>
-    extends _$PackageApiCopyWithImpl<$Res, _$_PackageApi>
+class __$$_PackageApiCopyWithImpl<$Res> extends _$PackageApiCopyWithImpl<$Res>
     implements _$$_PackageApiCopyWith<$Res> {
   __$$_PackageApiCopyWithImpl(
       _$_PackageApi _value, $Res Function(_$_PackageApi) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_PackageApi));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_PackageApi get _value => super._value as _$_PackageApi;
+
   @override
   $Res call({
-    Object? packageName = null,
+    Object? packageName = freezed,
     Object? packageVersion = freezed,
-    Object? packagePath = null,
-    Object? classDeclarations = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? typeAliasDeclarations = null,
-    Object? semantics = null,
+    Object? packagePath = freezed,
+    Object? interfaceDeclarations = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
+    Object? typeAliasDeclarations = freezed,
+    Object? semantics = freezed,
     Object? androidPlatformConstraints = freezed,
     Object? iosPlatformConstraints = freezed,
-    Object? sdkType = null,
-    Object? minSdkVersion = null,
+    Object? sdkType = freezed,
+    Object? minSdkVersion = freezed,
   }) {
     return _then(_$_PackageApi(
-      packageName: null == packageName
+      packageName: packageName == freezed
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: freezed == packageVersion
+      packageVersion: packageVersion == freezed
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: null == packagePath
+      packagePath: packagePath == freezed
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: null == classDeclarations
-          ? _value._classDeclarations
-          : classDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ClassDeclaration>,
-      executableDeclarations: null == executableDeclarations
+      interfaceDeclarations: interfaceDeclarations == freezed
+          ? _value._interfaceDeclarations
+          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<InterfaceDeclaration>,
+      executableDeclarations: executableDeclarations == freezed
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
-      typeAliasDeclarations: null == typeAliasDeclarations
+      typeAliasDeclarations: typeAliasDeclarations == freezed
           ? _value._typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclaration>,
-      semantics: null == semantics
+      semantics: semantics == freezed
           ? _value._semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      androidPlatformConstraints: freezed == androidPlatformConstraints
+      androidPlatformConstraints: androidPlatformConstraints == freezed
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraints?,
-      iosPlatformConstraints: freezed == iosPlatformConstraints
+      iosPlatformConstraints: iosPlatformConstraints == freezed
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraints?,
-      sdkType: null == sdkType
+      sdkType: sdkType == freezed
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkType,
-      minSdkVersion: null == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
@@ -304,7 +298,7 @@ class _$_PackageApi extends _PackageApi {
       {required this.packageName,
       required this.packageVersion,
       required this.packagePath,
-      required final List<ClassDeclaration> classDeclarations,
+      required final List<InterfaceDeclaration> interfaceDeclarations,
       required final List<ExecutableDeclaration> executableDeclarations,
       required final List<FieldDeclaration> fieldDeclarations,
       required final List<TypeAliasDeclaration> typeAliasDeclarations,
@@ -313,7 +307,7 @@ class _$_PackageApi extends _PackageApi {
       this.iosPlatformConstraints,
       required this.sdkType,
       required this.minSdkVersion})
-      : _classDeclarations = classDeclarations,
+      : _interfaceDeclarations = interfaceDeclarations,
         _executableDeclarations = executableDeclarations,
         _fieldDeclarations = fieldDeclarations,
         _typeAliasDeclarations = typeAliasDeclarations,
@@ -332,14 +326,14 @@ class _$_PackageApi extends _PackageApi {
   @override
   final String packagePath;
 
-  /// class declarations this package has
-  final List<ClassDeclaration> _classDeclarations;
+  /// interface declarations this package has
+  final List<InterfaceDeclaration> _interfaceDeclarations;
 
-  /// class declarations this package has
+  /// interface declarations this package has
   @override
-  List<ClassDeclaration> get classDeclarations {
+  List<InterfaceDeclaration> get interfaceDeclarations {
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_classDeclarations);
+    return EqualUnmodifiableListView(_interfaceDeclarations);
   }
 
   /// root level executable declarations this package has
@@ -401,7 +395,7 @@ class _$_PackageApi extends _PackageApi {
 
   @override
   String toString() {
-    return 'PackageApi(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, classDeclarations: $classDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, androidPlatformConstraints: $androidPlatformConstraints, iosPlatformConstraints: $iosPlatformConstraints, sdkType: $sdkType, minSdkVersion: $minSdkVersion)';
+    return 'PackageApi(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, androidPlatformConstraints: $androidPlatformConstraints, iosPlatformConstraints: $iosPlatformConstraints, sdkType: $sdkType, minSdkVersion: $minSdkVersion)';
   }
 
   @override
@@ -409,14 +403,14 @@ class _$_PackageApi extends _PackageApi {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PackageApi &&
-            (identical(other.packageName, packageName) ||
-                other.packageName == packageName) &&
-            (identical(other.packageVersion, packageVersion) ||
-                other.packageVersion == packageVersion) &&
-            (identical(other.packagePath, packagePath) ||
-                other.packagePath == packagePath) &&
             const DeepCollectionEquality()
-                .equals(other._classDeclarations, _classDeclarations) &&
+                .equals(other.packageName, packageName) &&
+            const DeepCollectionEquality()
+                .equals(other.packageVersion, packageVersion) &&
+            const DeepCollectionEquality()
+                .equals(other.packagePath, packagePath) &&
+            const DeepCollectionEquality()
+                .equals(other._interfaceDeclarations, _interfaceDeclarations) &&
             const DeepCollectionEquality().equals(
                 other._executableDeclarations, _executableDeclarations) &&
             const DeepCollectionEquality()
@@ -425,36 +419,33 @@ class _$_PackageApi extends _PackageApi {
                 .equals(other._typeAliasDeclarations, _typeAliasDeclarations) &&
             const DeepCollectionEquality()
                 .equals(other._semantics, _semantics) &&
-            (identical(other.androidPlatformConstraints,
-                    androidPlatformConstraints) ||
-                other.androidPlatformConstraints ==
-                    androidPlatformConstraints) &&
-            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
-                other.iosPlatformConstraints == iosPlatformConstraints) &&
-            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
-            (identical(other.minSdkVersion, minSdkVersion) ||
-                other.minSdkVersion == minSdkVersion));
+            const DeepCollectionEquality().equals(
+                other.androidPlatformConstraints, androidPlatformConstraints) &&
+            const DeepCollectionEquality()
+                .equals(other.iosPlatformConstraints, iosPlatformConstraints) &&
+            const DeepCollectionEquality().equals(other.sdkType, sdkType) &&
+            const DeepCollectionEquality()
+                .equals(other.minSdkVersion, minSdkVersion));
   }
 
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      packageName,
-      packageVersion,
-      packagePath,
-      const DeepCollectionEquality().hash(_classDeclarations),
+      const DeepCollectionEquality().hash(packageName),
+      const DeepCollectionEquality().hash(packageVersion),
+      const DeepCollectionEquality().hash(packagePath),
+      const DeepCollectionEquality().hash(_interfaceDeclarations),
       const DeepCollectionEquality().hash(_executableDeclarations),
       const DeepCollectionEquality().hash(_fieldDeclarations),
       const DeepCollectionEquality().hash(_typeAliasDeclarations),
       const DeepCollectionEquality().hash(_semantics),
-      androidPlatformConstraints,
-      iosPlatformConstraints,
-      sdkType,
-      minSdkVersion);
+      const DeepCollectionEquality().hash(androidPlatformConstraints),
+      const DeepCollectionEquality().hash(iosPlatformConstraints),
+      const DeepCollectionEquality().hash(sdkType),
+      const DeepCollectionEquality().hash(minSdkVersion));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_PackageApiCopyWith<_$_PackageApi> get copyWith =>
       __$$_PackageApiCopyWithImpl<_$_PackageApi>(this, _$identity);
 }
@@ -464,7 +455,7 @@ abstract class _PackageApi extends PackageApi {
       {required final String packageName,
       required final String? packageVersion,
       required final String packagePath,
-      required final List<ClassDeclaration> classDeclarations,
+      required final List<InterfaceDeclaration> interfaceDeclarations,
       required final List<ExecutableDeclaration> executableDeclarations,
       required final List<FieldDeclaration> fieldDeclarations,
       required final List<TypeAliasDeclaration> typeAliasDeclarations,
@@ -489,8 +480,8 @@ abstract class _PackageApi extends PackageApi {
   String get packagePath;
   @override
 
-  /// class declarations this package has
-  List<ClassDeclaration> get classDeclarations;
+  /// interface declarations this package has
+  List<InterfaceDeclaration> get interfaceDeclarations;
   @override
 
   /// root level executable declarations this package has

--- a/lib/src/model/platform_constraints.freezed.dart
+++ b/lib/src/model/platform_constraints.freezed.dart
@@ -27,33 +27,29 @@ mixin _$IOSPlatformConstraints {
 abstract class $IOSPlatformConstraintsCopyWith<$Res> {
   factory $IOSPlatformConstraintsCopyWith(IOSPlatformConstraints value,
           $Res Function(IOSPlatformConstraints) then) =
-      _$IOSPlatformConstraintsCopyWithImpl<$Res, IOSPlatformConstraints>;
-  @useResult
+      _$IOSPlatformConstraintsCopyWithImpl<$Res>;
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
-class _$IOSPlatformConstraintsCopyWithImpl<$Res,
-        $Val extends IOSPlatformConstraints>
+class _$IOSPlatformConstraintsCopyWithImpl<$Res>
     implements $IOSPlatformConstraintsCopyWith<$Res> {
   _$IOSPlatformConstraintsCopyWithImpl(this._value, this._then);
 
+  final IOSPlatformConstraints _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(IOSPlatformConstraints) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minimumOsVersion: freezed == minimumOsVersion
+      minimumOsVersion: minimumOsVersion == freezed
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
-    ) as $Val);
+    ));
   }
 }
 
@@ -64,26 +60,27 @@ abstract class _$$_IOSPlatformConstraintsCopyWith<$Res>
           $Res Function(_$_IOSPlatformConstraints) then) =
       __$$_IOSPlatformConstraintsCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
 class __$$_IOSPlatformConstraintsCopyWithImpl<$Res>
-    extends _$IOSPlatformConstraintsCopyWithImpl<$Res,
-        _$_IOSPlatformConstraints>
+    extends _$IOSPlatformConstraintsCopyWithImpl<$Res>
     implements _$$_IOSPlatformConstraintsCopyWith<$Res> {
   __$$_IOSPlatformConstraintsCopyWithImpl(_$_IOSPlatformConstraints _value,
       $Res Function(_$_IOSPlatformConstraints) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_IOSPlatformConstraints));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_IOSPlatformConstraints get _value =>
+      super._value as _$_IOSPlatformConstraints;
+
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_$_IOSPlatformConstraints(
-      minimumOsVersion: freezed == minimumOsVersion
+      minimumOsVersion: minimumOsVersion == freezed
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
@@ -109,16 +106,16 @@ class _$_IOSPlatformConstraints implements _IOSPlatformConstraints {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_IOSPlatformConstraints &&
-            (identical(other.minimumOsVersion, minimumOsVersion) ||
-                other.minimumOsVersion == minimumOsVersion));
+            const DeepCollectionEquality()
+                .equals(other.minimumOsVersion, minimumOsVersion));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, minimumOsVersion);
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(minimumOsVersion));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_IOSPlatformConstraintsCopyWith<_$_IOSPlatformConstraints> get copyWith =>
       __$$_IOSPlatformConstraintsCopyWithImpl<_$_IOSPlatformConstraints>(
           this, _$identity);
@@ -151,25 +148,20 @@ mixin _$AndroidPlatformConstraints {
 abstract class $AndroidPlatformConstraintsCopyWith<$Res> {
   factory $AndroidPlatformConstraintsCopyWith(AndroidPlatformConstraints value,
           $Res Function(AndroidPlatformConstraints) then) =
-      _$AndroidPlatformConstraintsCopyWithImpl<$Res,
-          AndroidPlatformConstraints>;
-  @useResult
+      _$AndroidPlatformConstraintsCopyWithImpl<$Res>;
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
-class _$AndroidPlatformConstraintsCopyWithImpl<$Res,
-        $Val extends AndroidPlatformConstraints>
+class _$AndroidPlatformConstraintsCopyWithImpl<$Res>
     implements $AndroidPlatformConstraintsCopyWith<$Res> {
   _$AndroidPlatformConstraintsCopyWithImpl(this._value, this._then);
 
+  final AndroidPlatformConstraints _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(AndroidPlatformConstraints) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -177,19 +169,19 @@ class _$AndroidPlatformConstraintsCopyWithImpl<$Res,
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minSdkVersion: freezed == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: freezed == compileSdkVersion
+      compileSdkVersion: compileSdkVersion == freezed
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: freezed == targetSdkVersion
+      targetSdkVersion: targetSdkVersion == freezed
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-    ) as $Val);
+    ));
   }
 }
 
@@ -201,22 +193,23 @@ abstract class _$$_AndroidPlatformConstraintsCopyWith<$Res>
           $Res Function(_$_AndroidPlatformConstraints) then) =
       __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
 class __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>
-    extends _$AndroidPlatformConstraintsCopyWithImpl<$Res,
-        _$_AndroidPlatformConstraints>
+    extends _$AndroidPlatformConstraintsCopyWithImpl<$Res>
     implements _$$_AndroidPlatformConstraintsCopyWith<$Res> {
   __$$_AndroidPlatformConstraintsCopyWithImpl(
       _$_AndroidPlatformConstraints _value,
       $Res Function(_$_AndroidPlatformConstraints) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_AndroidPlatformConstraints));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_AndroidPlatformConstraints get _value =>
+      super._value as _$_AndroidPlatformConstraints;
+
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -224,15 +217,15 @@ class __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_$_AndroidPlatformConstraints(
-      minSdkVersion: freezed == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: freezed == compileSdkVersion
+      compileSdkVersion: compileSdkVersion == freezed
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: freezed == targetSdkVersion
+      targetSdkVersion: targetSdkVersion == freezed
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
@@ -265,21 +258,23 @@ class _$_AndroidPlatformConstraints implements _AndroidPlatformConstraints {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_AndroidPlatformConstraints &&
-            (identical(other.minSdkVersion, minSdkVersion) ||
-                other.minSdkVersion == minSdkVersion) &&
-            (identical(other.compileSdkVersion, compileSdkVersion) ||
-                other.compileSdkVersion == compileSdkVersion) &&
-            (identical(other.targetSdkVersion, targetSdkVersion) ||
-                other.targetSdkVersion == targetSdkVersion));
+            const DeepCollectionEquality()
+                .equals(other.minSdkVersion, minSdkVersion) &&
+            const DeepCollectionEquality()
+                .equals(other.compileSdkVersion, compileSdkVersion) &&
+            const DeepCollectionEquality()
+                .equals(other.targetSdkVersion, targetSdkVersion));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
+      runtimeType,
+      const DeepCollectionEquality().hash(minSdkVersion),
+      const DeepCollectionEquality().hash(compileSdkVersion),
+      const DeepCollectionEquality().hash(targetSdkVersion));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_AndroidPlatformConstraintsCopyWith<_$_AndroidPlatformConstraints>
       get copyWith => __$$_AndroidPlatformConstraintsCopyWithImpl<
           _$_AndroidPlatformConstraints>(this, _$identity);

--- a/lib/src/model/platform_constraints.freezed.dart
+++ b/lib/src/model/platform_constraints.freezed.dart
@@ -27,29 +27,33 @@ mixin _$IOSPlatformConstraints {
 abstract class $IOSPlatformConstraintsCopyWith<$Res> {
   factory $IOSPlatformConstraintsCopyWith(IOSPlatformConstraints value,
           $Res Function(IOSPlatformConstraints) then) =
-      _$IOSPlatformConstraintsCopyWithImpl<$Res>;
+      _$IOSPlatformConstraintsCopyWithImpl<$Res, IOSPlatformConstraints>;
+  @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
-class _$IOSPlatformConstraintsCopyWithImpl<$Res>
+class _$IOSPlatformConstraintsCopyWithImpl<$Res,
+        $Val extends IOSPlatformConstraints>
     implements $IOSPlatformConstraintsCopyWith<$Res> {
   _$IOSPlatformConstraintsCopyWithImpl(this._value, this._then);
 
-  final IOSPlatformConstraints _value;
   // ignore: unused_field
-  final $Res Function(IOSPlatformConstraints) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minimumOsVersion: minimumOsVersion == freezed
+      minimumOsVersion: freezed == minimumOsVersion
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -60,27 +64,26 @@ abstract class _$$_IOSPlatformConstraintsCopyWith<$Res>
           $Res Function(_$_IOSPlatformConstraints) then) =
       __$$_IOSPlatformConstraintsCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
 class __$$_IOSPlatformConstraintsCopyWithImpl<$Res>
-    extends _$IOSPlatformConstraintsCopyWithImpl<$Res>
+    extends _$IOSPlatformConstraintsCopyWithImpl<$Res,
+        _$_IOSPlatformConstraints>
     implements _$$_IOSPlatformConstraintsCopyWith<$Res> {
   __$$_IOSPlatformConstraintsCopyWithImpl(_$_IOSPlatformConstraints _value,
       $Res Function(_$_IOSPlatformConstraints) _then)
-      : super(_value, (v) => _then(v as _$_IOSPlatformConstraints));
+      : super(_value, _then);
 
-  @override
-  _$_IOSPlatformConstraints get _value =>
-      super._value as _$_IOSPlatformConstraints;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_$_IOSPlatformConstraints(
-      minimumOsVersion: minimumOsVersion == freezed
+      minimumOsVersion: freezed == minimumOsVersion
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
@@ -106,16 +109,16 @@ class _$_IOSPlatformConstraints implements _IOSPlatformConstraints {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_IOSPlatformConstraints &&
-            const DeepCollectionEquality()
-                .equals(other.minimumOsVersion, minimumOsVersion));
+            (identical(other.minimumOsVersion, minimumOsVersion) ||
+                other.minimumOsVersion == minimumOsVersion));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(minimumOsVersion));
+  int get hashCode => Object.hash(runtimeType, minimumOsVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_IOSPlatformConstraintsCopyWith<_$_IOSPlatformConstraints> get copyWith =>
       __$$_IOSPlatformConstraintsCopyWithImpl<_$_IOSPlatformConstraints>(
           this, _$identity);
@@ -148,20 +151,25 @@ mixin _$AndroidPlatformConstraints {
 abstract class $AndroidPlatformConstraintsCopyWith<$Res> {
   factory $AndroidPlatformConstraintsCopyWith(AndroidPlatformConstraints value,
           $Res Function(AndroidPlatformConstraints) then) =
-      _$AndroidPlatformConstraintsCopyWithImpl<$Res>;
+      _$AndroidPlatformConstraintsCopyWithImpl<$Res,
+          AndroidPlatformConstraints>;
+  @useResult
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
-class _$AndroidPlatformConstraintsCopyWithImpl<$Res>
+class _$AndroidPlatformConstraintsCopyWithImpl<$Res,
+        $Val extends AndroidPlatformConstraints>
     implements $AndroidPlatformConstraintsCopyWith<$Res> {
   _$AndroidPlatformConstraintsCopyWithImpl(this._value, this._then);
 
-  final AndroidPlatformConstraints _value;
   // ignore: unused_field
-  final $Res Function(AndroidPlatformConstraints) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -169,19 +177,19 @@ class _$AndroidPlatformConstraintsCopyWithImpl<$Res>
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: freezed == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: compileSdkVersion == freezed
+      compileSdkVersion: freezed == compileSdkVersion
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: targetSdkVersion == freezed
+      targetSdkVersion: freezed == targetSdkVersion
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -193,23 +201,22 @@ abstract class _$$_AndroidPlatformConstraintsCopyWith<$Res>
           $Res Function(_$_AndroidPlatformConstraints) then) =
       __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
 class __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>
-    extends _$AndroidPlatformConstraintsCopyWithImpl<$Res>
+    extends _$AndroidPlatformConstraintsCopyWithImpl<$Res,
+        _$_AndroidPlatformConstraints>
     implements _$$_AndroidPlatformConstraintsCopyWith<$Res> {
   __$$_AndroidPlatformConstraintsCopyWithImpl(
       _$_AndroidPlatformConstraints _value,
       $Res Function(_$_AndroidPlatformConstraints) _then)
-      : super(_value, (v) => _then(v as _$_AndroidPlatformConstraints));
+      : super(_value, _then);
 
-  @override
-  _$_AndroidPlatformConstraints get _value =>
-      super._value as _$_AndroidPlatformConstraints;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -217,15 +224,15 @@ class __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_$_AndroidPlatformConstraints(
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: freezed == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: compileSdkVersion == freezed
+      compileSdkVersion: freezed == compileSdkVersion
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: targetSdkVersion == freezed
+      targetSdkVersion: freezed == targetSdkVersion
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
@@ -258,23 +265,21 @@ class _$_AndroidPlatformConstraints implements _AndroidPlatformConstraints {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_AndroidPlatformConstraints &&
-            const DeepCollectionEquality()
-                .equals(other.minSdkVersion, minSdkVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.compileSdkVersion, compileSdkVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.targetSdkVersion, targetSdkVersion));
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion) &&
+            (identical(other.compileSdkVersion, compileSdkVersion) ||
+                other.compileSdkVersion == compileSdkVersion) &&
+            (identical(other.targetSdkVersion, targetSdkVersion) ||
+                other.targetSdkVersion == targetSdkVersion));
   }
 
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(minSdkVersion),
-      const DeepCollectionEquality().hash(compileSdkVersion),
-      const DeepCollectionEquality().hash(targetSdkVersion));
+      runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_AndroidPlatformConstraintsCopyWith<_$_AndroidPlatformConstraints>
       get copyWith => __$$_AndroidPlatformConstraintsCopyWithImpl<
           _$_AndroidPlatformConstraints>(this, _$identity);

--- a/lib/src/model/type_alias_declaration.freezed.dart
+++ b/lib/src/model/type_alias_declaration.freezed.dart
@@ -30,8 +30,7 @@ mixin _$TypeAliasDeclaration {
 abstract class $TypeAliasDeclarationCopyWith<$Res> {
   factory $TypeAliasDeclarationCopyWith(TypeAliasDeclaration value,
           $Res Function(TypeAliasDeclaration) then) =
-      _$TypeAliasDeclarationCopyWithImpl<$Res, TypeAliasDeclaration>;
-  @useResult
+      _$TypeAliasDeclarationCopyWithImpl<$Res>;
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -40,42 +39,39 @@ abstract class $TypeAliasDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TypeAliasDeclarationCopyWithImpl<$Res,
-        $Val extends TypeAliasDeclaration>
+class _$TypeAliasDeclarationCopyWithImpl<$Res>
     implements $TypeAliasDeclarationCopyWith<$Res> {
   _$TypeAliasDeclarationCopyWithImpl(this._value, this._then);
 
+  final TypeAliasDeclaration _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(TypeAliasDeclaration) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
-    Object? aliasedTypeName = null,
-    Object? isDeprecated = null,
+    Object? name = freezed,
+    Object? aliasedTypeName = freezed,
+    Object? isDeprecated = freezed,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: null == aliasedTypeName
+      aliasedTypeName: aliasedTypeName == freezed
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ) as $Val);
+    ));
   }
 }
 
@@ -86,7 +82,6 @@ abstract class _$$_TypeAliasDeclarationCopyWith<$Res>
           $Res Function(_$_TypeAliasDeclaration) then) =
       __$$_TypeAliasDeclarationCopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -96,34 +91,36 @@ abstract class _$$_TypeAliasDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_TypeAliasDeclarationCopyWithImpl<$Res>
-    extends _$TypeAliasDeclarationCopyWithImpl<$Res, _$_TypeAliasDeclaration>
+    extends _$TypeAliasDeclarationCopyWithImpl<$Res>
     implements _$$_TypeAliasDeclarationCopyWith<$Res> {
   __$$_TypeAliasDeclarationCopyWithImpl(_$_TypeAliasDeclaration _value,
       $Res Function(_$_TypeAliasDeclaration) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_TypeAliasDeclaration));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_TypeAliasDeclaration get _value => super._value as _$_TypeAliasDeclaration;
+
   @override
   $Res call({
-    Object? name = null,
-    Object? aliasedTypeName = null,
-    Object? isDeprecated = null,
+    Object? name = freezed,
+    Object? aliasedTypeName = freezed,
+    Object? isDeprecated = freezed,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_TypeAliasDeclaration(
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: null == aliasedTypeName
+      aliasedTypeName: aliasedTypeName == freezed
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: freezed == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -167,22 +164,25 @@ class _$_TypeAliasDeclaration extends _TypeAliasDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_TypeAliasDeclaration &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.aliasedTypeName, aliasedTypeName) ||
-                other.aliasedTypeName == aliasedTypeName) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.aliasedTypeName, aliasedTypeName) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, name, aliasedTypeName,
-      isDeprecated, const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(aliasedTypeName),
+      const DeepCollectionEquality().hash(isDeprecated),
+      const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_TypeAliasDeclarationCopyWith<_$_TypeAliasDeclaration> get copyWith =>
       __$$_TypeAliasDeclarationCopyWithImpl<_$_TypeAliasDeclaration>(
           this, _$identity);

--- a/lib/src/model/type_alias_declaration.freezed.dart
+++ b/lib/src/model/type_alias_declaration.freezed.dart
@@ -30,7 +30,8 @@ mixin _$TypeAliasDeclaration {
 abstract class $TypeAliasDeclarationCopyWith<$Res> {
   factory $TypeAliasDeclarationCopyWith(TypeAliasDeclaration value,
           $Res Function(TypeAliasDeclaration) then) =
-      _$TypeAliasDeclarationCopyWithImpl<$Res>;
+      _$TypeAliasDeclarationCopyWithImpl<$Res, TypeAliasDeclaration>;
+  @useResult
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -39,39 +40,42 @@ abstract class $TypeAliasDeclarationCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TypeAliasDeclarationCopyWithImpl<$Res>
+class _$TypeAliasDeclarationCopyWithImpl<$Res,
+        $Val extends TypeAliasDeclaration>
     implements $TypeAliasDeclarationCopyWith<$Res> {
   _$TypeAliasDeclarationCopyWithImpl(this._value, this._then);
 
-  final TypeAliasDeclaration _value;
   // ignore: unused_field
-  final $Res Function(TypeAliasDeclaration) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? aliasedTypeName = freezed,
-    Object? isDeprecated = freezed,
+    Object? name = null,
+    Object? aliasedTypeName = null,
+    Object? isDeprecated = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: aliasedTypeName == freezed
+      aliasedTypeName: null == aliasedTypeName
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -82,6 +86,7 @@ abstract class _$$_TypeAliasDeclarationCopyWith<$Res>
           $Res Function(_$_TypeAliasDeclaration) then) =
       __$$_TypeAliasDeclarationCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -91,36 +96,34 @@ abstract class _$$_TypeAliasDeclarationCopyWith<$Res>
 
 /// @nodoc
 class __$$_TypeAliasDeclarationCopyWithImpl<$Res>
-    extends _$TypeAliasDeclarationCopyWithImpl<$Res>
+    extends _$TypeAliasDeclarationCopyWithImpl<$Res, _$_TypeAliasDeclaration>
     implements _$$_TypeAliasDeclarationCopyWith<$Res> {
   __$$_TypeAliasDeclarationCopyWithImpl(_$_TypeAliasDeclaration _value,
       $Res Function(_$_TypeAliasDeclaration) _then)
-      : super(_value, (v) => _then(v as _$_TypeAliasDeclaration));
+      : super(_value, _then);
 
-  @override
-  _$_TypeAliasDeclaration get _value => super._value as _$_TypeAliasDeclaration;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? aliasedTypeName = freezed,
-    Object? isDeprecated = freezed,
+    Object? name = null,
+    Object? aliasedTypeName = null,
+    Object? isDeprecated = null,
     Object? entryPoints = freezed,
   }) {
     return _then(_$_TypeAliasDeclaration(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: aliasedTypeName == freezed
+      aliasedTypeName: null == aliasedTypeName
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: freezed == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
@@ -164,25 +167,22 @@ class _$_TypeAliasDeclaration extends _TypeAliasDeclaration {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_TypeAliasDeclaration &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.aliasedTypeName, aliasedTypeName) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.aliasedTypeName, aliasedTypeName) ||
+                other.aliasedTypeName == aliasedTypeName) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(aliasedTypeName),
-      const DeepCollectionEquality().hash(isDeprecated),
-      const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(runtimeType, name, aliasedTypeName,
+      isDeprecated, const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_TypeAliasDeclarationCopyWith<_$_TypeAliasDeclaration> get copyWith =>
       __$$_TypeAliasDeclarationCopyWithImpl<_$_TypeAliasDeclaration>(
           this, _$identity);

--- a/lib/src/storage/v3/class_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/class_declaration_storage_v3.freezed.dart
@@ -41,7 +41,8 @@ mixin _$ClassDeclarationStorageV3 {
 abstract class $ClassDeclarationStorageV3CopyWith<$Res> {
   factory $ClassDeclarationStorageV3CopyWith(ClassDeclarationStorageV3 value,
           $Res Function(ClassDeclarationStorageV3) then) =
-      _$ClassDeclarationStorageV3CopyWithImpl<$Res>;
+      _$ClassDeclarationStorageV3CopyWithImpl<$Res, ClassDeclarationStorageV3>;
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -53,54 +54,57 @@ abstract class $ClassDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ClassDeclarationStorageV3CopyWithImpl<$Res>
+class _$ClassDeclarationStorageV3CopyWithImpl<$Res,
+        $Val extends ClassDeclarationStorageV3>
     implements $ClassDeclarationStorageV3CopyWith<$Res> {
   _$ClassDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
-  final ClassDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(ClassDeclarationStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? entryPoints = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? entryPoints = null,
   }) {
     return _then(_value.copyWith(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -112,6 +116,7 @@ abstract class _$$_ClassDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_ClassDeclarationStorageV3) then) =
       __$$_ClassDeclarationStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -124,53 +129,51 @@ abstract class _$$_ClassDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_ClassDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$ClassDeclarationStorageV3CopyWithImpl<$Res>
+    extends _$ClassDeclarationStorageV3CopyWithImpl<$Res,
+        _$_ClassDeclarationStorageV3>
     implements _$$_ClassDeclarationStorageV3CopyWith<$Res> {
   __$$_ClassDeclarationStorageV3CopyWithImpl(
       _$_ClassDeclarationStorageV3 _value,
       $Res Function(_$_ClassDeclarationStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_ClassDeclarationStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_ClassDeclarationStorageV3 get _value =>
-      super._value as _$_ClassDeclarationStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? entryPoints = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? entryPoints = null,
   }) {
     return _then(_$_ClassDeclarationStorageV3(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value._superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -249,9 +252,9 @@ class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ClassDeclarationStorageV3 &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -268,8 +271,8 @@ class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
+      name,
+      isDeprecated,
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -278,6 +281,7 @@ class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ClassDeclarationStorageV3CopyWith<_$_ClassDeclarationStorageV3>
       get copyWith => __$$_ClassDeclarationStorageV3CopyWithImpl<
           _$_ClassDeclarationStorageV3>(this, _$identity);

--- a/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
@@ -40,9 +40,7 @@ abstract class $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
   factory $ExecutableParameterDeclarationStorageV3CopyWith(
           ExecutableParameterDeclarationStorageV3 value,
           $Res Function(ExecutableParameterDeclarationStorageV3) then) =
-      _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
-          ExecutableParameterDeclarationStorageV3>;
-  @useResult
+      _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>;
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -52,48 +50,45 @@ abstract class $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends ExecutableParameterDeclarationStorageV3>
+class _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
     implements $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
   _$ExecutableParameterDeclarationStorageV3CopyWithImpl(
       this._value, this._then);
 
+  final ExecutableParameterDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(ExecutableParameterDeclarationStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isRequired = null,
-    Object? isNamed = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeName = null,
+    Object? isRequired = freezed,
+    Object? isNamed = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeName = freezed,
   }) {
     return _then(_value.copyWith(
-      isRequired: null == isRequired
+      isRequired: isRequired == freezed
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: null == isNamed
+      isNamed: isNamed == freezed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-    ) as $Val);
+    ));
   }
 }
 
@@ -105,7 +100,6 @@ abstract class _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_ExecutableParameterDeclarationStorageV3) then) =
       __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -116,41 +110,44 @@ abstract class _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
-        _$_ExecutableParameterDeclarationStorageV3>
+    extends _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
     implements _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
   __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl(
       _$_ExecutableParameterDeclarationStorageV3 _value,
       $Res Function(_$_ExecutableParameterDeclarationStorageV3) _then)
-      : super(_value, _then);
+      : super(_value,
+            (v) => _then(v as _$_ExecutableParameterDeclarationStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_ExecutableParameterDeclarationStorageV3 get _value =>
+      super._value as _$_ExecutableParameterDeclarationStorageV3;
+
   @override
   $Res call({
-    Object? isRequired = null,
-    Object? isNamed = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeName = null,
+    Object? isRequired = freezed,
+    Object? isNamed = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeName = freezed,
   }) {
     return _then(_$_ExecutableParameterDeclarationStorageV3(
-      isRequired: null == isRequired
+      isRequired: isRequired == freezed
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: null == isNamed
+      isNamed: isNamed == freezed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
@@ -195,24 +192,27 @@ class _$_ExecutableParameterDeclarationStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableParameterDeclarationStorageV3 &&
-            (identical(other.isRequired, isRequired) ||
-                other.isRequired == isRequired) &&
-            (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
-            (identical(other.typeName, typeName) ||
-                other.typeName == typeName));
+            const DeepCollectionEquality()
+                .equals(other.isRequired, isRequired) &&
+            const DeepCollectionEquality().equals(other.isNamed, isNamed) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
+            const DeepCollectionEquality().equals(other.typeName, typeName));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType, isRequired, isNamed, name, isDeprecated, typeName);
+      runtimeType,
+      const DeepCollectionEquality().hash(isRequired),
+      const DeepCollectionEquality().hash(isNamed),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
+      const DeepCollectionEquality().hash(typeName));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_ExecutableParameterDeclarationStorageV3CopyWith<
           _$_ExecutableParameterDeclarationStorageV3>
       get copyWith => __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<
@@ -286,9 +286,7 @@ abstract class $ExecutableDeclarationStorageV3CopyWith<$Res> {
   factory $ExecutableDeclarationStorageV3CopyWith(
           ExecutableDeclarationStorageV3 value,
           $Res Function(ExecutableDeclarationStorageV3) then) =
-      _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
-          ExecutableDeclarationStorageV3>;
-  @useResult
+      _$ExecutableDeclarationStorageV3CopyWithImpl<$Res>;
   $Res call(
       {String returnTypeName,
       String name,
@@ -301,62 +299,59 @@ abstract class $ExecutableDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends ExecutableDeclarationStorageV3>
+class _$ExecutableDeclarationStorageV3CopyWithImpl<$Res>
     implements $ExecutableDeclarationStorageV3CopyWith<$Res> {
   _$ExecutableDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
+  final ExecutableDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(ExecutableDeclarationStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? returnTypeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? parameters = null,
-    Object? typeParameterNames = null,
-    Object? type = null,
-    Object? isStatic = null,
-    Object? entryPoints = null,
+    Object? returnTypeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? parameters = freezed,
+    Object? typeParameterNames = freezed,
+    Object? type = freezed,
+    Object? isStatic = freezed,
+    Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      returnTypeName: null == returnTypeName
+      returnTypeName: returnTypeName == freezed
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: null == parameters
+      parameters: parameters == freezed
           ? _value.parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclarationStorageV3>,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: null == type
+      type: type == freezed
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableTypeStorageV3,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ) as $Val);
+    ));
   }
 }
 
@@ -368,7 +363,6 @@ abstract class _$$_ExecutableDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_ExecutableDeclarationStorageV3) then) =
       __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String returnTypeName,
       String name,
@@ -382,56 +376,58 @@ abstract class _$$_ExecutableDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
-        _$_ExecutableDeclarationStorageV3>
+    extends _$ExecutableDeclarationStorageV3CopyWithImpl<$Res>
     implements _$$_ExecutableDeclarationStorageV3CopyWith<$Res> {
   __$$_ExecutableDeclarationStorageV3CopyWithImpl(
       _$_ExecutableDeclarationStorageV3 _value,
       $Res Function(_$_ExecutableDeclarationStorageV3) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_ExecutableDeclarationStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_ExecutableDeclarationStorageV3 get _value =>
+      super._value as _$_ExecutableDeclarationStorageV3;
+
   @override
   $Res call({
-    Object? returnTypeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? parameters = null,
-    Object? typeParameterNames = null,
-    Object? type = null,
-    Object? isStatic = null,
-    Object? entryPoints = null,
+    Object? returnTypeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? parameters = freezed,
+    Object? typeParameterNames = freezed,
+    Object? type = freezed,
+    Object? isStatic = freezed,
+    Object? entryPoints = freezed,
   }) {
     return _then(_$_ExecutableDeclarationStorageV3(
-      returnTypeName: null == returnTypeName
+      returnTypeName: returnTypeName == freezed
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: null == parameters
+      parameters: parameters == freezed
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclarationStorageV3>,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: null == type
+      type: type == freezed
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableTypeStorageV3,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -502,18 +498,17 @@ class _$_ExecutableDeclarationStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableDeclarationStorageV3 &&
-            (identical(other.returnTypeName, returnTypeName) ||
-                other.returnTypeName == returnTypeName) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
+            const DeepCollectionEquality()
+                .equals(other.returnTypeName, returnTypeName) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.isStatic, isStatic) ||
-                other.isStatic == isStatic) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
+            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
@@ -522,18 +517,17 @@ class _$_ExecutableDeclarationStorageV3
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      returnTypeName,
-      name,
-      isDeprecated,
+      const DeepCollectionEquality().hash(returnTypeName),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
       const DeepCollectionEquality().hash(_parameters),
       const DeepCollectionEquality().hash(_typeParameterNames),
-      type,
-      isStatic,
+      const DeepCollectionEquality().hash(type),
+      const DeepCollectionEquality().hash(isStatic),
       const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_ExecutableDeclarationStorageV3CopyWith<_$_ExecutableDeclarationStorageV3>
       get copyWith => __$$_ExecutableDeclarationStorageV3CopyWithImpl<
           _$_ExecutableDeclarationStorageV3>(this, _$identity);

--- a/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
@@ -40,7 +40,9 @@ abstract class $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
   factory $ExecutableParameterDeclarationStorageV3CopyWith(
           ExecutableParameterDeclarationStorageV3 value,
           $Res Function(ExecutableParameterDeclarationStorageV3) then) =
-      _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>;
+      _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
+          ExecutableParameterDeclarationStorageV3>;
+  @useResult
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -50,45 +52,48 @@ abstract class $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
+class _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
+        $Val extends ExecutableParameterDeclarationStorageV3>
     implements $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
   _$ExecutableParameterDeclarationStorageV3CopyWithImpl(
       this._value, this._then);
 
-  final ExecutableParameterDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(ExecutableParameterDeclarationStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isRequired = freezed,
-    Object? isNamed = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeName = freezed,
+    Object? isRequired = null,
+    Object? isNamed = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeName = null,
   }) {
     return _then(_value.copyWith(
-      isRequired: isRequired == freezed
+      isRequired: null == isRequired
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: isNamed == freezed
+      isNamed: null == isNamed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-    ));
+    ) as $Val);
   }
 }
 
@@ -100,6 +105,7 @@ abstract class _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_ExecutableParameterDeclarationStorageV3) then) =
       __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {bool isRequired,
       bool isNamed,
@@ -110,44 +116,41 @@ abstract class _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
+    extends _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
+        _$_ExecutableParameterDeclarationStorageV3>
     implements _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
   __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl(
       _$_ExecutableParameterDeclarationStorageV3 _value,
       $Res Function(_$_ExecutableParameterDeclarationStorageV3) _then)
-      : super(_value,
-            (v) => _then(v as _$_ExecutableParameterDeclarationStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_ExecutableParameterDeclarationStorageV3 get _value =>
-      super._value as _$_ExecutableParameterDeclarationStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isRequired = freezed,
-    Object? isNamed = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeName = freezed,
+    Object? isRequired = null,
+    Object? isNamed = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeName = null,
   }) {
     return _then(_$_ExecutableParameterDeclarationStorageV3(
-      isRequired: isRequired == freezed
+      isRequired: null == isRequired
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
-      isNamed: isNamed == freezed
+      isNamed: null == isNamed
           ? _value.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
@@ -192,27 +195,24 @@ class _$_ExecutableParameterDeclarationStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableParameterDeclarationStorageV3 &&
-            const DeepCollectionEquality()
-                .equals(other.isRequired, isRequired) &&
-            const DeepCollectionEquality().equals(other.isNamed, isNamed) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
-            const DeepCollectionEquality().equals(other.typeName, typeName));
+            (identical(other.isRequired, isRequired) ||
+                other.isRequired == isRequired) &&
+            (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(isRequired),
-      const DeepCollectionEquality().hash(isNamed),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
-      const DeepCollectionEquality().hash(typeName));
+      runtimeType, isRequired, isNamed, name, isDeprecated, typeName);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ExecutableParameterDeclarationStorageV3CopyWith<
           _$_ExecutableParameterDeclarationStorageV3>
       get copyWith => __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<
@@ -286,7 +286,9 @@ abstract class $ExecutableDeclarationStorageV3CopyWith<$Res> {
   factory $ExecutableDeclarationStorageV3CopyWith(
           ExecutableDeclarationStorageV3 value,
           $Res Function(ExecutableDeclarationStorageV3) then) =
-      _$ExecutableDeclarationStorageV3CopyWithImpl<$Res>;
+      _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
+          ExecutableDeclarationStorageV3>;
+  @useResult
   $Res call(
       {String returnTypeName,
       String name,
@@ -299,59 +301,62 @@ abstract class $ExecutableDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ExecutableDeclarationStorageV3CopyWithImpl<$Res>
+class _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
+        $Val extends ExecutableDeclarationStorageV3>
     implements $ExecutableDeclarationStorageV3CopyWith<$Res> {
   _$ExecutableDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
-  final ExecutableDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(ExecutableDeclarationStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? returnTypeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? parameters = freezed,
-    Object? typeParameterNames = freezed,
-    Object? type = freezed,
-    Object? isStatic = freezed,
-    Object? entryPoints = freezed,
+    Object? returnTypeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? parameters = null,
+    Object? typeParameterNames = null,
+    Object? type = null,
+    Object? isStatic = null,
+    Object? entryPoints = null,
   }) {
     return _then(_value.copyWith(
-      returnTypeName: returnTypeName == freezed
+      returnTypeName: null == returnTypeName
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: parameters == freezed
+      parameters: null == parameters
           ? _value.parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclarationStorageV3>,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: type == freezed
+      type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableTypeStorageV3,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -363,6 +368,7 @@ abstract class _$$_ExecutableDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_ExecutableDeclarationStorageV3) then) =
       __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String returnTypeName,
       String name,
@@ -376,58 +382,56 @@ abstract class _$$_ExecutableDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$ExecutableDeclarationStorageV3CopyWithImpl<$Res>
+    extends _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
+        _$_ExecutableDeclarationStorageV3>
     implements _$$_ExecutableDeclarationStorageV3CopyWith<$Res> {
   __$$_ExecutableDeclarationStorageV3CopyWithImpl(
       _$_ExecutableDeclarationStorageV3 _value,
       $Res Function(_$_ExecutableDeclarationStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_ExecutableDeclarationStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_ExecutableDeclarationStorageV3 get _value =>
-      super._value as _$_ExecutableDeclarationStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? returnTypeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? parameters = freezed,
-    Object? typeParameterNames = freezed,
-    Object? type = freezed,
-    Object? isStatic = freezed,
-    Object? entryPoints = freezed,
+    Object? returnTypeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? parameters = null,
+    Object? typeParameterNames = null,
+    Object? type = null,
+    Object? isStatic = null,
+    Object? entryPoints = null,
   }) {
     return _then(_$_ExecutableDeclarationStorageV3(
-      returnTypeName: returnTypeName == freezed
+      returnTypeName: null == returnTypeName
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: parameters == freezed
+      parameters: null == parameters
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclarationStorageV3>,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      type: type == freezed
+      type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableTypeStorageV3,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -498,17 +502,18 @@ class _$_ExecutableDeclarationStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_ExecutableDeclarationStorageV3 &&
-            const DeepCollectionEquality()
-                .equals(other.returnTypeName, returnTypeName) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.returnTypeName, returnTypeName) ||
+                other.returnTypeName == returnTypeName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
-            const DeepCollectionEquality().equals(other.type, type) &&
-            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
@@ -517,17 +522,18 @@ class _$_ExecutableDeclarationStorageV3
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(returnTypeName),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
+      returnTypeName,
+      name,
+      isDeprecated,
       const DeepCollectionEquality().hash(_parameters),
       const DeepCollectionEquality().hash(_typeParameterNames),
-      const DeepCollectionEquality().hash(type),
-      const DeepCollectionEquality().hash(isStatic),
+      type,
+      isStatic,
       const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_ExecutableDeclarationStorageV3CopyWith<_$_ExecutableDeclarationStorageV3>
       get copyWith => __$$_ExecutableDeclarationStorageV3CopyWithImpl<
           _$_ExecutableDeclarationStorageV3>(this, _$identity);

--- a/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
@@ -37,7 +37,8 @@ mixin _$FieldDeclarationStorageV3 {
 abstract class $FieldDeclarationStorageV3CopyWith<$Res> {
   factory $FieldDeclarationStorageV3CopyWith(FieldDeclarationStorageV3 value,
           $Res Function(FieldDeclarationStorageV3) then) =
-      _$FieldDeclarationStorageV3CopyWithImpl<$Res>;
+      _$FieldDeclarationStorageV3CopyWithImpl<$Res, FieldDeclarationStorageV3>;
+  @useResult
   $Res call(
       {String typeName,
       String name,
@@ -47,44 +48,47 @@ abstract class $FieldDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$FieldDeclarationStorageV3CopyWithImpl<$Res>
+class _$FieldDeclarationStorageV3CopyWithImpl<$Res,
+        $Val extends FieldDeclarationStorageV3>
     implements $FieldDeclarationStorageV3CopyWith<$Res> {
   _$FieldDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
-  final FieldDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(FieldDeclarationStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? typeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? isStatic = freezed,
-    Object? entryPoints = freezed,
+    Object? typeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isStatic = null,
+    Object? entryPoints = null,
   }) {
     return _then(_value.copyWith(
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -96,6 +100,7 @@ abstract class _$$_FieldDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_FieldDeclarationStorageV3) then) =
       __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String typeName,
       String name,
@@ -106,43 +111,41 @@ abstract class _$$_FieldDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$FieldDeclarationStorageV3CopyWithImpl<$Res>
+    extends _$FieldDeclarationStorageV3CopyWithImpl<$Res,
+        _$_FieldDeclarationStorageV3>
     implements _$$_FieldDeclarationStorageV3CopyWith<$Res> {
   __$$_FieldDeclarationStorageV3CopyWithImpl(
       _$_FieldDeclarationStorageV3 _value,
       $Res Function(_$_FieldDeclarationStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_FieldDeclarationStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_FieldDeclarationStorageV3 get _value =>
-      super._value as _$_FieldDeclarationStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? typeName = freezed,
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? isStatic = freezed,
-    Object? entryPoints = freezed,
+    Object? typeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isStatic = null,
+    Object? entryPoints = null,
   }) {
     return _then(_$_FieldDeclarationStorageV3(
-      typeName: typeName == freezed
+      typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: isStatic == freezed
+      isStatic: null == isStatic
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -190,27 +193,25 @@ class _$_FieldDeclarationStorageV3 extends _FieldDeclarationStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_FieldDeclarationStorageV3 &&
-            const DeepCollectionEquality().equals(other.typeName, typeName) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
-            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(typeName),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
-      const DeepCollectionEquality().hash(isStatic),
-      const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(runtimeType, typeName, name, isDeprecated,
+      isStatic, const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_FieldDeclarationStorageV3CopyWith<_$_FieldDeclarationStorageV3>
       get copyWith => __$$_FieldDeclarationStorageV3CopyWithImpl<
           _$_FieldDeclarationStorageV3>(this, _$identity);

--- a/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
@@ -37,8 +37,7 @@ mixin _$FieldDeclarationStorageV3 {
 abstract class $FieldDeclarationStorageV3CopyWith<$Res> {
   factory $FieldDeclarationStorageV3CopyWith(FieldDeclarationStorageV3 value,
           $Res Function(FieldDeclarationStorageV3) then) =
-      _$FieldDeclarationStorageV3CopyWithImpl<$Res, FieldDeclarationStorageV3>;
-  @useResult
+      _$FieldDeclarationStorageV3CopyWithImpl<$Res>;
   $Res call(
       {String typeName,
       String name,
@@ -48,47 +47,44 @@ abstract class $FieldDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$FieldDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends FieldDeclarationStorageV3>
+class _$FieldDeclarationStorageV3CopyWithImpl<$Res>
     implements $FieldDeclarationStorageV3CopyWith<$Res> {
   _$FieldDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
+  final FieldDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(FieldDeclarationStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? typeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isStatic = null,
-    Object? entryPoints = null,
+    Object? typeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? isStatic = freezed,
+    Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ) as $Val);
+    ));
   }
 }
 
@@ -100,7 +96,6 @@ abstract class _$$_FieldDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_FieldDeclarationStorageV3) then) =
       __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String typeName,
       String name,
@@ -111,41 +106,43 @@ abstract class _$$_FieldDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$FieldDeclarationStorageV3CopyWithImpl<$Res,
-        _$_FieldDeclarationStorageV3>
+    extends _$FieldDeclarationStorageV3CopyWithImpl<$Res>
     implements _$$_FieldDeclarationStorageV3CopyWith<$Res> {
   __$$_FieldDeclarationStorageV3CopyWithImpl(
       _$_FieldDeclarationStorageV3 _value,
       $Res Function(_$_FieldDeclarationStorageV3) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_FieldDeclarationStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_FieldDeclarationStorageV3 get _value =>
+      super._value as _$_FieldDeclarationStorageV3;
+
   @override
   $Res call({
-    Object? typeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isStatic = null,
-    Object? entryPoints = null,
+    Object? typeName = freezed,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? isStatic = freezed,
+    Object? entryPoints = freezed,
   }) {
     return _then(_$_FieldDeclarationStorageV3(
-      typeName: null == typeName
+      typeName: typeName == freezed
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      isStatic: null == isStatic
+      isStatic: isStatic == freezed
           ? _value.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -193,25 +190,27 @@ class _$_FieldDeclarationStorageV3 extends _FieldDeclarationStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_FieldDeclarationStorageV3 &&
-            (identical(other.typeName, typeName) ||
-                other.typeName == typeName) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
-            (identical(other.isStatic, isStatic) ||
-                other.isStatic == isStatic) &&
+            const DeepCollectionEquality().equals(other.typeName, typeName) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
+            const DeepCollectionEquality().equals(other.isStatic, isStatic) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, typeName, name, isDeprecated,
-      isStatic, const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(typeName),
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
+      const DeepCollectionEquality().hash(isStatic),
+      const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_FieldDeclarationStorageV3CopyWith<_$_FieldDeclarationStorageV3>
       get copyWith => __$$_FieldDeclarationStorageV3CopyWithImpl<
           _$_FieldDeclarationStorageV3>(this, _$identity);

--- a/lib/src/storage/v3/interface_declaration_storage_v3.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.dart
@@ -6,15 +6,15 @@ import '../../model/model.dart';
 import 'executable_declaration_storage_v3.dart';
 import 'field_declaration_storage_v3.dart';
 
-part 'class_declaration_storage_v3.freezed.dart';
-part 'class_declaration_storage_v3.g.dart';
+part 'interface_declaration_storage_v3.freezed.dart';
+part 'interface_declaration_storage_v3.g.dart';
 
 /// Represents a found class declaration
 @freezed
-class ClassDeclarationStorageV3 with _$ClassDeclarationStorageV3 {
-  const ClassDeclarationStorageV3._();
+class InterfaceDeclarationStorageV3 with _$InterfaceDeclarationStorageV3 {
+  const InterfaceDeclarationStorageV3._();
 
-  const factory ClassDeclarationStorageV3({
+  const factory InterfaceDeclarationStorageV3({
     required String name,
     required bool isDeprecated,
     required List<String> typeParameterNames,
@@ -22,13 +22,13 @@ class ClassDeclarationStorageV3 with _$ClassDeclarationStorageV3 {
     required List<ExecutableDeclarationStorageV3> executableDeclarations,
     required List<FieldDeclarationStorageV3> fieldDeclarations,
     required Set<String> entryPoints,
-  }) = _ClassDeclarationStorageV3;
+  }) = _InterfaceDeclarationStorageV3;
 
-  factory ClassDeclarationStorageV3.fromJson(Map<String, Object?> json) =>
-      _$ClassDeclarationStorageV3FromJson(json);
+  factory InterfaceDeclarationStorageV3.fromJson(Map<String, Object?> json) =>
+      _$InterfaceDeclarationStorageV3FromJson(json);
 
-  ClassDeclaration toClassDeclaration() {
-    return ClassDeclaration(
+  InterfaceDeclaration toInterfaceDeclaration() {
+    return InterfaceDeclaration(
       name: name,
       isDeprecated: isDeprecated,
       typeParameterNames: typeParameterNames,
@@ -42,21 +42,21 @@ class ClassDeclarationStorageV3 with _$ClassDeclarationStorageV3 {
     );
   }
 
-  static ClassDeclarationStorageV3 fromClassDeclaration(
-      ClassDeclaration classDeclaration) {
-    return ClassDeclarationStorageV3(
-      name: classDeclaration.name,
-      isDeprecated: classDeclaration.isDeprecated,
-      typeParameterNames: classDeclaration.typeParameterNames,
-      superTypeNames: classDeclaration.superTypeNames,
-      executableDeclarations: classDeclaration.executableDeclarations
+  static InterfaceDeclarationStorageV3 fromInterfaceDeclaration(
+      InterfaceDeclaration interfaceDeclaration) {
+    return InterfaceDeclarationStorageV3(
+      name: interfaceDeclaration.name,
+      isDeprecated: interfaceDeclaration.isDeprecated,
+      typeParameterNames: interfaceDeclaration.typeParameterNames,
+      superTypeNames: interfaceDeclaration.superTypeNames,
+      executableDeclarations: interfaceDeclaration.executableDeclarations
           .map((e) =>
               ExecutableDeclarationStorageV3.fromExecutableDeclaration(e))
           .toList(),
-      fieldDeclarations: classDeclaration.fieldDeclarations
+      fieldDeclarations: interfaceDeclaration.fieldDeclarations
           .map((f) => FieldDeclarationStorageV3.fromFieldDeclaration(f))
           .toList(),
-      entryPoints: classDeclaration.entryPoints!,
+      entryPoints: interfaceDeclaration.entryPoints!,
     );
   }
 }

--- a/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
@@ -3,7 +3,7 @@
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
-part of 'class_declaration_storage_v3.dart';
+part of 'interface_declaration_storage_v3.dart';
 
 // **************************************************************************
 // FreezedGenerator
@@ -14,13 +14,13 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
-ClassDeclarationStorageV3 _$ClassDeclarationStorageV3FromJson(
+InterfaceDeclarationStorageV3 _$InterfaceDeclarationStorageV3FromJson(
     Map<String, dynamic> json) {
-  return _ClassDeclarationStorageV3.fromJson(json);
+  return _InterfaceDeclarationStorageV3.fromJson(json);
 }
 
 /// @nodoc
-mixin _$ClassDeclarationStorageV3 {
+mixin _$InterfaceDeclarationStorageV3 {
   String get name => throw _privateConstructorUsedError;
   bool get isDeprecated => throw _privateConstructorUsedError;
   List<String> get typeParameterNames => throw _privateConstructorUsedError;
@@ -33,16 +33,16 @@ mixin _$ClassDeclarationStorageV3 {
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
-  $ClassDeclarationStorageV3CopyWith<ClassDeclarationStorageV3> get copyWith =>
-      throw _privateConstructorUsedError;
+  $InterfaceDeclarationStorageV3CopyWith<InterfaceDeclarationStorageV3>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class $ClassDeclarationStorageV3CopyWith<$Res> {
-  factory $ClassDeclarationStorageV3CopyWith(ClassDeclarationStorageV3 value,
-          $Res Function(ClassDeclarationStorageV3) then) =
-      _$ClassDeclarationStorageV3CopyWithImpl<$Res, ClassDeclarationStorageV3>;
-  @useResult
+abstract class $InterfaceDeclarationStorageV3CopyWith<$Res> {
+  factory $InterfaceDeclarationStorageV3CopyWith(
+          InterfaceDeclarationStorageV3 value,
+          $Res Function(InterfaceDeclarationStorageV3) then) =
+      _$InterfaceDeclarationStorageV3CopyWithImpl<$Res>;
   $Res call(
       {String name,
       bool isDeprecated,
@@ -54,69 +54,65 @@ abstract class $ClassDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$ClassDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends ClassDeclarationStorageV3>
-    implements $ClassDeclarationStorageV3CopyWith<$Res> {
-  _$ClassDeclarationStorageV3CopyWithImpl(this._value, this._then);
+class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+    implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
+  _$InterfaceDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
+  final InterfaceDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(InterfaceDeclarationStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeParameterNames = null,
-    Object? superTypeNames = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? entryPoints = null,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeParameterNames = freezed,
+    Object? superTypeNames = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
+    Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: null == superTypeNames
+      superTypeNames: superTypeNames == freezed
           ? _value.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: null == executableDeclarations
+      executableDeclarations: executableDeclarations == freezed
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ) as $Val);
+    ));
   }
 }
 
 /// @nodoc
-abstract class _$$_ClassDeclarationStorageV3CopyWith<$Res>
-    implements $ClassDeclarationStorageV3CopyWith<$Res> {
-  factory _$$_ClassDeclarationStorageV3CopyWith(
-          _$_ClassDeclarationStorageV3 value,
-          $Res Function(_$_ClassDeclarationStorageV3) then) =
-      __$$_ClassDeclarationStorageV3CopyWithImpl<$Res>;
+abstract class _$$_InterfaceDeclarationStorageV3CopyWith<$Res>
+    implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
+  factory _$$_InterfaceDeclarationStorageV3CopyWith(
+          _$_InterfaceDeclarationStorageV3 value,
+          $Res Function(_$_InterfaceDeclarationStorageV3) then) =
+      __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -128,52 +124,54 @@ abstract class _$$_ClassDeclarationStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ClassDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$ClassDeclarationStorageV3CopyWithImpl<$Res,
-        _$_ClassDeclarationStorageV3>
-    implements _$$_ClassDeclarationStorageV3CopyWith<$Res> {
-  __$$_ClassDeclarationStorageV3CopyWithImpl(
-      _$_ClassDeclarationStorageV3 _value,
-      $Res Function(_$_ClassDeclarationStorageV3) _then)
-      : super(_value, _then);
+class __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+    extends _$InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+    implements _$$_InterfaceDeclarationStorageV3CopyWith<$Res> {
+  __$$_InterfaceDeclarationStorageV3CopyWithImpl(
+      _$_InterfaceDeclarationStorageV3 _value,
+      $Res Function(_$_InterfaceDeclarationStorageV3) _then)
+      : super(_value, (v) => _then(v as _$_InterfaceDeclarationStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_InterfaceDeclarationStorageV3 get _value =>
+      super._value as _$_InterfaceDeclarationStorageV3;
+
   @override
   $Res call({
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? typeParameterNames = null,
-    Object? superTypeNames = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? entryPoints = null,
+    Object? name = freezed,
+    Object? isDeprecated = freezed,
+    Object? typeParameterNames = freezed,
+    Object? superTypeNames = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
+    Object? entryPoints = freezed,
   }) {
-    return _then(_$_ClassDeclarationStorageV3(
-      name: null == name
+    return _then(_$_InterfaceDeclarationStorageV3(
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: null == typeParameterNames
+      typeParameterNames: typeParameterNames == freezed
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: null == superTypeNames
+      superTypeNames: superTypeNames == freezed
           ? _value._superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: null == executableDeclarations
+      executableDeclarations: executableDeclarations == freezed
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -183,8 +181,8 @@ class __$$_ClassDeclarationStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
-  const _$_ClassDeclarationStorageV3(
+class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
+  const _$_InterfaceDeclarationStorageV3(
       {required this.name,
       required this.isDeprecated,
       required final List<String> typeParameterNames,
@@ -200,8 +198,9 @@ class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
         _entryPoints = entryPoints,
         super._();
 
-  factory _$_ClassDeclarationStorageV3.fromJson(Map<String, dynamic> json) =>
-      _$$_ClassDeclarationStorageV3FromJson(json);
+  factory _$_InterfaceDeclarationStorageV3.fromJson(
+          Map<String, dynamic> json) =>
+      _$$_InterfaceDeclarationStorageV3FromJson(json);
 
   @override
   final String name;
@@ -244,17 +243,17 @@ class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
 
   @override
   String toString() {
-    return 'ClassDeclarationStorageV3(name: $name, isDeprecated: $isDeprecated, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
+    return 'InterfaceDeclarationStorageV3(name: $name, isDeprecated: $isDeprecated, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ClassDeclarationStorageV3 &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
+            other is _$_InterfaceDeclarationStorageV3 &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -271,8 +270,8 @@ class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      name,
-      isDeprecated,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(isDeprecated),
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -281,33 +280,34 @@ class _$_ClassDeclarationStorageV3 extends _ClassDeclarationStorageV3 {
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
-  _$$_ClassDeclarationStorageV3CopyWith<_$_ClassDeclarationStorageV3>
-      get copyWith => __$$_ClassDeclarationStorageV3CopyWithImpl<
-          _$_ClassDeclarationStorageV3>(this, _$identity);
+  _$$_InterfaceDeclarationStorageV3CopyWith<_$_InterfaceDeclarationStorageV3>
+      get copyWith => __$$_InterfaceDeclarationStorageV3CopyWithImpl<
+          _$_InterfaceDeclarationStorageV3>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ClassDeclarationStorageV3ToJson(
+    return _$$_InterfaceDeclarationStorageV3ToJson(
       this,
     );
   }
 }
 
-abstract class _ClassDeclarationStorageV3 extends ClassDeclarationStorageV3 {
-  const factory _ClassDeclarationStorageV3(
-      {required final String name,
-      required final bool isDeprecated,
-      required final List<String> typeParameterNames,
-      required final List<String> superTypeNames,
-      required final List<ExecutableDeclarationStorageV3>
-          executableDeclarations,
-      required final List<FieldDeclarationStorageV3> fieldDeclarations,
-      required final Set<String> entryPoints}) = _$_ClassDeclarationStorageV3;
-  const _ClassDeclarationStorageV3._() : super._();
+abstract class _InterfaceDeclarationStorageV3
+    extends InterfaceDeclarationStorageV3 {
+  const factory _InterfaceDeclarationStorageV3(
+          {required final String name,
+          required final bool isDeprecated,
+          required final List<String> typeParameterNames,
+          required final List<String> superTypeNames,
+          required final List<ExecutableDeclarationStorageV3>
+              executableDeclarations,
+          required final List<FieldDeclarationStorageV3> fieldDeclarations,
+          required final Set<String> entryPoints}) =
+      _$_InterfaceDeclarationStorageV3;
+  const _InterfaceDeclarationStorageV3._() : super._();
 
-  factory _ClassDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_ClassDeclarationStorageV3.fromJson;
+  factory _InterfaceDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
+      _$_InterfaceDeclarationStorageV3.fromJson;
 
   @override
   String get name;
@@ -325,6 +325,6 @@ abstract class _ClassDeclarationStorageV3 extends ClassDeclarationStorageV3 {
   Set<String> get entryPoints;
   @override
   @JsonKey(ignore: true)
-  _$$_ClassDeclarationStorageV3CopyWith<_$_ClassDeclarationStorageV3>
+  _$$_InterfaceDeclarationStorageV3CopyWith<_$_InterfaceDeclarationStorageV3>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
@@ -42,7 +42,9 @@ abstract class $InterfaceDeclarationStorageV3CopyWith<$Res> {
   factory $InterfaceDeclarationStorageV3CopyWith(
           InterfaceDeclarationStorageV3 value,
           $Res Function(InterfaceDeclarationStorageV3) then) =
-      _$InterfaceDeclarationStorageV3CopyWithImpl<$Res>;
+      _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
+          InterfaceDeclarationStorageV3>;
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -54,54 +56,57 @@ abstract class $InterfaceDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
+        $Val extends InterfaceDeclarationStorageV3>
     implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
   _$InterfaceDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
-  final InterfaceDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(InterfaceDeclarationStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? entryPoints = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? entryPoints = null,
   }) {
     return _then(_value.copyWith(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -113,6 +118,7 @@ abstract class _$$_InterfaceDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_InterfaceDeclarationStorageV3) then) =
       __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String name,
       bool isDeprecated,
@@ -125,53 +131,51 @@ abstract class _$$_InterfaceDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+    extends _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
+        _$_InterfaceDeclarationStorageV3>
     implements _$$_InterfaceDeclarationStorageV3CopyWith<$Res> {
   __$$_InterfaceDeclarationStorageV3CopyWithImpl(
       _$_InterfaceDeclarationStorageV3 _value,
       $Res Function(_$_InterfaceDeclarationStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_InterfaceDeclarationStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_InterfaceDeclarationStorageV3 get _value =>
-      super._value as _$_InterfaceDeclarationStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? isDeprecated = freezed,
-    Object? typeParameterNames = freezed,
-    Object? superTypeNames = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? entryPoints = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? entryPoints = null,
   }) {
     return _then(_$_InterfaceDeclarationStorageV3(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      typeParameterNames: typeParameterNames == freezed
+      typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      superTypeNames: superTypeNames == freezed
+      superTypeNames: null == superTypeNames
           ? _value._superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -251,9 +255,9 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_InterfaceDeclarationStorageV3 &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -270,8 +274,8 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(isDeprecated),
+      name,
+      isDeprecated,
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -280,6 +284,7 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_InterfaceDeclarationStorageV3CopyWith<_$_InterfaceDeclarationStorageV3>
       get copyWith => __$$_InterfaceDeclarationStorageV3CopyWithImpl<
           _$_InterfaceDeclarationStorageV3>(this, _$identity);

--- a/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
@@ -2,15 +2,15 @@
 
 // ignore_for_file: non_constant_identifier_names
 
-part of 'class_declaration_storage_v3.dart';
+part of 'interface_declaration_storage_v3.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ClassDeclarationStorageV3 _$$_ClassDeclarationStorageV3FromJson(
+_$_InterfaceDeclarationStorageV3 _$$_InterfaceDeclarationStorageV3FromJson(
         Map<String, dynamic> json) =>
-    _$_ClassDeclarationStorageV3(
+    _$_InterfaceDeclarationStorageV3(
       name: json['name'] as String,
       isDeprecated: json['isDeprecated'] as bool,
       typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
@@ -32,8 +32,8 @@ _$_ClassDeclarationStorageV3 _$$_ClassDeclarationStorageV3FromJson(
           .toSet(),
     );
 
-Map<String, dynamic> _$$_ClassDeclarationStorageV3ToJson(
-        _$_ClassDeclarationStorageV3 instance) =>
+Map<String, dynamic> _$$_InterfaceDeclarationStorageV3ToJson(
+        _$_InterfaceDeclarationStorageV3 instance) =>
     <String, dynamic>{
       'name': instance.name,
       'isDeprecated': instance.isDeprecated,

--- a/lib/src/storage/v3/package_api_storage_v3.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.dart
@@ -18,7 +18,7 @@ class PackageApiStorageV3 with _$PackageApiStorageV3 {
     required String packageName,
     required String? packageVersion,
     required String packagePath,
-    required List<ClassDeclarationStorageV3> classDeclarations,
+    required List<InterfaceDeclarationStorageV3> interfaceDeclarations,
     required List<ExecutableDeclarationStorageV3> executableDeclarations,
     required List<FieldDeclarationStorageV3> fieldDeclarations,
     required List<TypeAliasDeclarationStorageV3> typeAliasDeclarations,
@@ -38,8 +38,9 @@ class PackageApiStorageV3 with _$PackageApiStorageV3 {
       packageName: packageName,
       packageVersion: packageVersion,
       packagePath: packagePath,
-      classDeclarations:
-          classDeclarations.map((cd) => cd.toClassDeclaration()).toList(),
+      interfaceDeclarations: interfaceDeclarations
+          .map((cd) => cd.toInterfaceDeclaration())
+          .toList(),
       executableDeclarations: executableDeclarations
           .map((e) => e.toExecutableDeclaration())
           .toList(),
@@ -63,8 +64,8 @@ class PackageApiStorageV3 with _$PackageApiStorageV3 {
       packageName: packageApi.packageName,
       packageVersion: packageApi.packageVersion,
       packagePath: packageApi.packagePath,
-      classDeclarations: packageApi.classDeclarations
-          .map((c) => ClassDeclarationStorageV3.fromClassDeclaration(c))
+      interfaceDeclarations: packageApi.interfaceDeclarations
+          .map((c) => InterfaceDeclarationStorageV3.fromInterfaceDeclaration(c))
           .toList(),
       executableDeclarations: packageApi.executableDeclarations
           .map((e) =>

--- a/lib/src/storage/v3/package_api_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.freezed.dart
@@ -50,7 +50,8 @@ mixin _$PackageApiStorageV3 {
 abstract class $PackageApiStorageV3CopyWith<$Res> {
   factory $PackageApiStorageV3CopyWith(
           PackageApiStorageV3 value, $Res Function(PackageApiStorageV3) then) =
-      _$PackageApiStorageV3CopyWithImpl<$Res>;
+      _$PackageApiStorageV3CopyWithImpl<$Res, PackageApiStorageV3>;
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -71,82 +72,85 @@ abstract class $PackageApiStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiStorageV3CopyWithImpl<$Res>
+class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
     implements $PackageApiStorageV3CopyWith<$Res> {
   _$PackageApiStorageV3CopyWithImpl(this._value, this._then);
 
-  final PackageApiStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(PackageApiStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? classDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? classDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? iosPlatformConstraints = freezed,
     Object? androidPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_value.copyWith(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: classDeclarations == freezed
+      classDeclarations: null == classDeclarations
           ? _value.classDeclarations
           : classDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ClassDeclarationStorageV3>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclarationStorageV3>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraintsStorageV3?,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraintsStorageV3?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkTypeStorageV3,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsStorageV3CopyWith<$Res>? get iosPlatformConstraints {
     if (_value.iosPlatformConstraints == null) {
       return null;
@@ -154,11 +158,12 @@ class _$PackageApiStorageV3CopyWithImpl<$Res>
 
     return $IOSPlatformConstraintsStorageV3CopyWith<$Res>(
         _value.iosPlatformConstraints!, (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value));
+      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsStorageV3CopyWith<$Res>?
       get androidPlatformConstraints {
     if (_value.androidPlatformConstraints == null) {
@@ -167,7 +172,7 @@ class _$PackageApiStorageV3CopyWithImpl<$Res>
 
     return $AndroidPlatformConstraintsStorageV3CopyWith<$Res>(
         _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value));
+      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
     });
   }
 }
@@ -179,6 +184,7 @@ abstract class _$$_PackageApiStorageV3CopyWith<$Res>
           $Res Function(_$_PackageApiStorageV3) then) =
       __$$_PackageApiStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -202,76 +208,74 @@ abstract class _$$_PackageApiStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_PackageApiStorageV3CopyWithImpl<$Res>
-    extends _$PackageApiStorageV3CopyWithImpl<$Res>
+    extends _$PackageApiStorageV3CopyWithImpl<$Res, _$_PackageApiStorageV3>
     implements _$$_PackageApiStorageV3CopyWith<$Res> {
   __$$_PackageApiStorageV3CopyWithImpl(_$_PackageApiStorageV3 _value,
       $Res Function(_$_PackageApiStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_PackageApiStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_PackageApiStorageV3 get _value => super._value as _$_PackageApiStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? classDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? classDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? iosPlatformConstraints = freezed,
     Object? androidPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_$_PackageApiStorageV3(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: classDeclarations == freezed
+      classDeclarations: null == classDeclarations
           ? _value._classDeclarations
           : classDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ClassDeclarationStorageV3>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value._typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclarationStorageV3>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value._semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraintsStorageV3?,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraintsStorageV3?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkTypeStorageV3,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
@@ -367,12 +371,12 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PackageApiStorageV3 &&
-            const DeepCollectionEquality()
-                .equals(other.packageName, packageName) &&
-            const DeepCollectionEquality()
-                .equals(other.packageVersion, packageVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.packagePath, packagePath) &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion) &&
+            (identical(other.packagePath, packagePath) ||
+                other.packagePath == packagePath) &&
             const DeepCollectionEquality()
                 .equals(other._classDeclarations, _classDeclarations) &&
             const DeepCollectionEquality().equals(
@@ -383,34 +387,37 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
                 .equals(other._typeAliasDeclarations, _typeAliasDeclarations) &&
             const DeepCollectionEquality()
                 .equals(other._semantics, _semantics) &&
-            const DeepCollectionEquality()
-                .equals(other.iosPlatformConstraints, iosPlatformConstraints) &&
-            const DeepCollectionEquality().equals(
-                other.androidPlatformConstraints, androidPlatformConstraints) &&
-            const DeepCollectionEquality().equals(other.sdkType, sdkType) &&
-            const DeepCollectionEquality()
-                .equals(other.minSdkVersion, minSdkVersion));
+            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
+                other.iosPlatformConstraints == iosPlatformConstraints) &&
+            (identical(other.androidPlatformConstraints,
+                    androidPlatformConstraints) ||
+                other.androidPlatformConstraints ==
+                    androidPlatformConstraints) &&
+            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(packageName),
-      const DeepCollectionEquality().hash(packageVersion),
-      const DeepCollectionEquality().hash(packagePath),
+      packageName,
+      packageVersion,
+      packagePath,
       const DeepCollectionEquality().hash(_classDeclarations),
       const DeepCollectionEquality().hash(_executableDeclarations),
       const DeepCollectionEquality().hash(_fieldDeclarations),
       const DeepCollectionEquality().hash(_typeAliasDeclarations),
       const DeepCollectionEquality().hash(_semantics),
-      const DeepCollectionEquality().hash(iosPlatformConstraints),
-      const DeepCollectionEquality().hash(androidPlatformConstraints),
-      const DeepCollectionEquality().hash(sdkType),
-      const DeepCollectionEquality().hash(minSdkVersion));
+      iosPlatformConstraints,
+      androidPlatformConstraints,
+      sdkType,
+      minSdkVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_PackageApiStorageV3CopyWith<_$_PackageApiStorageV3> get copyWith =>
       __$$_PackageApiStorageV3CopyWithImpl<_$_PackageApiStorageV3>(
           this, _$identity);

--- a/lib/src/storage/v3/package_api_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.freezed.dart
@@ -23,7 +23,7 @@ mixin _$PackageApiStorageV3 {
   String get packageName => throw _privateConstructorUsedError;
   String? get packageVersion => throw _privateConstructorUsedError;
   String get packagePath => throw _privateConstructorUsedError;
-  List<ClassDeclarationStorageV3> get classDeclarations =>
+  List<InterfaceDeclarationStorageV3> get interfaceDeclarations =>
       throw _privateConstructorUsedError;
   List<ExecutableDeclarationStorageV3> get executableDeclarations =>
       throw _privateConstructorUsedError;
@@ -50,13 +50,12 @@ mixin _$PackageApiStorageV3 {
 abstract class $PackageApiStorageV3CopyWith<$Res> {
   factory $PackageApiStorageV3CopyWith(
           PackageApiStorageV3 value, $Res Function(PackageApiStorageV3) then) =
-      _$PackageApiStorageV3CopyWithImpl<$Res, PackageApiStorageV3>;
-  @useResult
+      _$PackageApiStorageV3CopyWithImpl<$Res>;
   $Res call(
       {String packageName,
       String? packageVersion,
       String packagePath,
-      List<ClassDeclarationStorageV3> classDeclarations,
+      List<InterfaceDeclarationStorageV3> interfaceDeclarations,
       List<ExecutableDeclarationStorageV3> executableDeclarations,
       List<FieldDeclarationStorageV3> fieldDeclarations,
       List<TypeAliasDeclarationStorageV3> typeAliasDeclarations,
@@ -72,85 +71,82 @@ abstract class $PackageApiStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
+class _$PackageApiStorageV3CopyWithImpl<$Res>
     implements $PackageApiStorageV3CopyWith<$Res> {
   _$PackageApiStorageV3CopyWithImpl(this._value, this._then);
 
+  final PackageApiStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(PackageApiStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = null,
+    Object? packageName = freezed,
     Object? packageVersion = freezed,
-    Object? packagePath = null,
-    Object? classDeclarations = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? typeAliasDeclarations = null,
-    Object? semantics = null,
+    Object? packagePath = freezed,
+    Object? interfaceDeclarations = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
+    Object? typeAliasDeclarations = freezed,
+    Object? semantics = freezed,
     Object? iosPlatformConstraints = freezed,
     Object? androidPlatformConstraints = freezed,
-    Object? sdkType = null,
-    Object? minSdkVersion = null,
+    Object? sdkType = freezed,
+    Object? minSdkVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      packageName: null == packageName
+      packageName: packageName == freezed
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: freezed == packageVersion
+      packageVersion: packageVersion == freezed
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: null == packagePath
+      packagePath: packagePath == freezed
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: null == classDeclarations
-          ? _value.classDeclarations
-          : classDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ClassDeclarationStorageV3>,
-      executableDeclarations: null == executableDeclarations
+      interfaceDeclarations: interfaceDeclarations == freezed
+          ? _value.interfaceDeclarations
+          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<InterfaceDeclarationStorageV3>,
+      executableDeclarations: executableDeclarations == freezed
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      typeAliasDeclarations: null == typeAliasDeclarations
+      typeAliasDeclarations: typeAliasDeclarations == freezed
           ? _value.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclarationStorageV3>,
-      semantics: null == semantics
+      semantics: semantics == freezed
           ? _value.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      iosPlatformConstraints: freezed == iosPlatformConstraints
+      iosPlatformConstraints: iosPlatformConstraints == freezed
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraintsStorageV3?,
-      androidPlatformConstraints: freezed == androidPlatformConstraints
+      androidPlatformConstraints: androidPlatformConstraints == freezed
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraintsStorageV3?,
-      sdkType: null == sdkType
+      sdkType: sdkType == freezed
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkTypeStorageV3,
-      minSdkVersion: null == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
-    ) as $Val);
+    ));
   }
 
   @override
-  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsStorageV3CopyWith<$Res>? get iosPlatformConstraints {
     if (_value.iosPlatformConstraints == null) {
       return null;
@@ -158,12 +154,11 @@ class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
 
     return $IOSPlatformConstraintsStorageV3CopyWith<$Res>(
         _value.iosPlatformConstraints!, (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
+      return _then(_value.copyWith(iosPlatformConstraints: value));
     });
   }
 
   @override
-  @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsStorageV3CopyWith<$Res>?
       get androidPlatformConstraints {
     if (_value.androidPlatformConstraints == null) {
@@ -172,7 +167,7 @@ class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
 
     return $AndroidPlatformConstraintsStorageV3CopyWith<$Res>(
         _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
+      return _then(_value.copyWith(androidPlatformConstraints: value));
     });
   }
 }
@@ -184,12 +179,11 @@ abstract class _$$_PackageApiStorageV3CopyWith<$Res>
           $Res Function(_$_PackageApiStorageV3) then) =
       __$$_PackageApiStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
       String packagePath,
-      List<ClassDeclarationStorageV3> classDeclarations,
+      List<InterfaceDeclarationStorageV3> interfaceDeclarations,
       List<ExecutableDeclarationStorageV3> executableDeclarations,
       List<FieldDeclarationStorageV3> fieldDeclarations,
       List<TypeAliasDeclarationStorageV3> typeAliasDeclarations,
@@ -208,74 +202,76 @@ abstract class _$$_PackageApiStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_PackageApiStorageV3CopyWithImpl<$Res>
-    extends _$PackageApiStorageV3CopyWithImpl<$Res, _$_PackageApiStorageV3>
+    extends _$PackageApiStorageV3CopyWithImpl<$Res>
     implements _$$_PackageApiStorageV3CopyWith<$Res> {
   __$$_PackageApiStorageV3CopyWithImpl(_$_PackageApiStorageV3 _value,
       $Res Function(_$_PackageApiStorageV3) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_PackageApiStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_PackageApiStorageV3 get _value => super._value as _$_PackageApiStorageV3;
+
   @override
   $Res call({
-    Object? packageName = null,
+    Object? packageName = freezed,
     Object? packageVersion = freezed,
-    Object? packagePath = null,
-    Object? classDeclarations = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? typeAliasDeclarations = null,
-    Object? semantics = null,
+    Object? packagePath = freezed,
+    Object? interfaceDeclarations = freezed,
+    Object? executableDeclarations = freezed,
+    Object? fieldDeclarations = freezed,
+    Object? typeAliasDeclarations = freezed,
+    Object? semantics = freezed,
     Object? iosPlatformConstraints = freezed,
     Object? androidPlatformConstraints = freezed,
-    Object? sdkType = null,
-    Object? minSdkVersion = null,
+    Object? sdkType = freezed,
+    Object? minSdkVersion = freezed,
   }) {
     return _then(_$_PackageApiStorageV3(
-      packageName: null == packageName
+      packageName: packageName == freezed
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: freezed == packageVersion
+      packageVersion: packageVersion == freezed
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: null == packagePath
+      packagePath: packagePath == freezed
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      classDeclarations: null == classDeclarations
-          ? _value._classDeclarations
-          : classDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ClassDeclarationStorageV3>,
-      executableDeclarations: null == executableDeclarations
+      interfaceDeclarations: interfaceDeclarations == freezed
+          ? _value._interfaceDeclarations
+          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<InterfaceDeclarationStorageV3>,
+      executableDeclarations: executableDeclarations == freezed
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: null == fieldDeclarations
+      fieldDeclarations: fieldDeclarations == freezed
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      typeAliasDeclarations: null == typeAliasDeclarations
+      typeAliasDeclarations: typeAliasDeclarations == freezed
           ? _value._typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclarationStorageV3>,
-      semantics: null == semantics
+      semantics: semantics == freezed
           ? _value._semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      iosPlatformConstraints: freezed == iosPlatformConstraints
+      iosPlatformConstraints: iosPlatformConstraints == freezed
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraintsStorageV3?,
-      androidPlatformConstraints: freezed == androidPlatformConstraints
+      androidPlatformConstraints: androidPlatformConstraints == freezed
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraintsStorageV3?,
-      sdkType: null == sdkType
+      sdkType: sdkType == freezed
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkTypeStorageV3,
-      minSdkVersion: null == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
@@ -290,7 +286,7 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
       {required this.packageName,
       required this.packageVersion,
       required this.packagePath,
-      required final List<ClassDeclarationStorageV3> classDeclarations,
+      required final List<InterfaceDeclarationStorageV3> interfaceDeclarations,
       required final List<ExecutableDeclarationStorageV3>
           executableDeclarations,
       required final List<FieldDeclarationStorageV3> fieldDeclarations,
@@ -300,7 +296,7 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
       this.androidPlatformConstraints,
       required this.sdkType,
       @VersionJsonConverter() required this.minSdkVersion})
-      : _classDeclarations = classDeclarations,
+      : _interfaceDeclarations = interfaceDeclarations,
         _executableDeclarations = executableDeclarations,
         _fieldDeclarations = fieldDeclarations,
         _typeAliasDeclarations = typeAliasDeclarations,
@@ -316,11 +312,11 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
   final String? packageVersion;
   @override
   final String packagePath;
-  final List<ClassDeclarationStorageV3> _classDeclarations;
+  final List<InterfaceDeclarationStorageV3> _interfaceDeclarations;
   @override
-  List<ClassDeclarationStorageV3> get classDeclarations {
+  List<InterfaceDeclarationStorageV3> get interfaceDeclarations {
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_classDeclarations);
+    return EqualUnmodifiableListView(_interfaceDeclarations);
   }
 
   final List<ExecutableDeclarationStorageV3> _executableDeclarations;
@@ -363,7 +359,7 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
 
   @override
   String toString() {
-    return 'PackageApiStorageV3(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, classDeclarations: $classDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, iosPlatformConstraints: $iosPlatformConstraints, androidPlatformConstraints: $androidPlatformConstraints, sdkType: $sdkType, minSdkVersion: $minSdkVersion)';
+    return 'PackageApiStorageV3(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, iosPlatformConstraints: $iosPlatformConstraints, androidPlatformConstraints: $androidPlatformConstraints, sdkType: $sdkType, minSdkVersion: $minSdkVersion)';
   }
 
   @override
@@ -371,14 +367,14 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PackageApiStorageV3 &&
-            (identical(other.packageName, packageName) ||
-                other.packageName == packageName) &&
-            (identical(other.packageVersion, packageVersion) ||
-                other.packageVersion == packageVersion) &&
-            (identical(other.packagePath, packagePath) ||
-                other.packagePath == packagePath) &&
             const DeepCollectionEquality()
-                .equals(other._classDeclarations, _classDeclarations) &&
+                .equals(other.packageName, packageName) &&
+            const DeepCollectionEquality()
+                .equals(other.packageVersion, packageVersion) &&
+            const DeepCollectionEquality()
+                .equals(other.packagePath, packagePath) &&
+            const DeepCollectionEquality()
+                .equals(other._interfaceDeclarations, _interfaceDeclarations) &&
             const DeepCollectionEquality().equals(
                 other._executableDeclarations, _executableDeclarations) &&
             const DeepCollectionEquality()
@@ -387,37 +383,34 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
                 .equals(other._typeAliasDeclarations, _typeAliasDeclarations) &&
             const DeepCollectionEquality()
                 .equals(other._semantics, _semantics) &&
-            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
-                other.iosPlatformConstraints == iosPlatformConstraints) &&
-            (identical(other.androidPlatformConstraints,
-                    androidPlatformConstraints) ||
-                other.androidPlatformConstraints ==
-                    androidPlatformConstraints) &&
-            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
-            (identical(other.minSdkVersion, minSdkVersion) ||
-                other.minSdkVersion == minSdkVersion));
+            const DeepCollectionEquality()
+                .equals(other.iosPlatformConstraints, iosPlatformConstraints) &&
+            const DeepCollectionEquality().equals(
+                other.androidPlatformConstraints, androidPlatformConstraints) &&
+            const DeepCollectionEquality().equals(other.sdkType, sdkType) &&
+            const DeepCollectionEquality()
+                .equals(other.minSdkVersion, minSdkVersion));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      packageName,
-      packageVersion,
-      packagePath,
-      const DeepCollectionEquality().hash(_classDeclarations),
+      const DeepCollectionEquality().hash(packageName),
+      const DeepCollectionEquality().hash(packageVersion),
+      const DeepCollectionEquality().hash(packagePath),
+      const DeepCollectionEquality().hash(_interfaceDeclarations),
       const DeepCollectionEquality().hash(_executableDeclarations),
       const DeepCollectionEquality().hash(_fieldDeclarations),
       const DeepCollectionEquality().hash(_typeAliasDeclarations),
       const DeepCollectionEquality().hash(_semantics),
-      iosPlatformConstraints,
-      androidPlatformConstraints,
-      sdkType,
-      minSdkVersion);
+      const DeepCollectionEquality().hash(iosPlatformConstraints),
+      const DeepCollectionEquality().hash(androidPlatformConstraints),
+      const DeepCollectionEquality().hash(sdkType),
+      const DeepCollectionEquality().hash(minSdkVersion));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_PackageApiStorageV3CopyWith<_$_PackageApiStorageV3> get copyWith =>
       __$$_PackageApiStorageV3CopyWithImpl<_$_PackageApiStorageV3>(
           this, _$identity);
@@ -435,7 +428,7 @@ abstract class _PackageApiStorageV3 extends PackageApiStorageV3 {
       {required final String packageName,
       required final String? packageVersion,
       required final String packagePath,
-      required final List<ClassDeclarationStorageV3> classDeclarations,
+      required final List<InterfaceDeclarationStorageV3> interfaceDeclarations,
       required final List<ExecutableDeclarationStorageV3>
           executableDeclarations,
       required final List<FieldDeclarationStorageV3> fieldDeclarations,
@@ -458,7 +451,7 @@ abstract class _PackageApiStorageV3 extends PackageApiStorageV3 {
   @override
   String get packagePath;
   @override
-  List<ClassDeclarationStorageV3> get classDeclarations;
+  List<InterfaceDeclarationStorageV3> get interfaceDeclarations;
   @override
   List<ExecutableDeclarationStorageV3> get executableDeclarations;
   @override

--- a/lib/src/storage/v3/package_api_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.freezed.dart
@@ -50,7 +50,8 @@ mixin _$PackageApiStorageV3 {
 abstract class $PackageApiStorageV3CopyWith<$Res> {
   factory $PackageApiStorageV3CopyWith(
           PackageApiStorageV3 value, $Res Function(PackageApiStorageV3) then) =
-      _$PackageApiStorageV3CopyWithImpl<$Res>;
+      _$PackageApiStorageV3CopyWithImpl<$Res, PackageApiStorageV3>;
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -71,82 +72,85 @@ abstract class $PackageApiStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiStorageV3CopyWithImpl<$Res>
+class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
     implements $PackageApiStorageV3CopyWith<$Res> {
   _$PackageApiStorageV3CopyWithImpl(this._value, this._then);
 
-  final PackageApiStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(PackageApiStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? interfaceDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? interfaceDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? iosPlatformConstraints = freezed,
     Object? androidPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_value.copyWith(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      interfaceDeclarations: interfaceDeclarations == freezed
+      interfaceDeclarations: null == interfaceDeclarations
           ? _value.interfaceDeclarations
           : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
               as List<InterfaceDeclarationStorageV3>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclarationStorageV3>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraintsStorageV3?,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraintsStorageV3?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkTypeStorageV3,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsStorageV3CopyWith<$Res>? get iosPlatformConstraints {
     if (_value.iosPlatformConstraints == null) {
       return null;
@@ -154,11 +158,12 @@ class _$PackageApiStorageV3CopyWithImpl<$Res>
 
     return $IOSPlatformConstraintsStorageV3CopyWith<$Res>(
         _value.iosPlatformConstraints!, (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value));
+      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsStorageV3CopyWith<$Res>?
       get androidPlatformConstraints {
     if (_value.androidPlatformConstraints == null) {
@@ -167,7 +172,7 @@ class _$PackageApiStorageV3CopyWithImpl<$Res>
 
     return $AndroidPlatformConstraintsStorageV3CopyWith<$Res>(
         _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value));
+      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
     });
   }
 }
@@ -179,6 +184,7 @@ abstract class _$$_PackageApiStorageV3CopyWith<$Res>
           $Res Function(_$_PackageApiStorageV3) then) =
       __$$_PackageApiStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String packageName,
       String? packageVersion,
@@ -202,76 +208,74 @@ abstract class _$$_PackageApiStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_PackageApiStorageV3CopyWithImpl<$Res>
-    extends _$PackageApiStorageV3CopyWithImpl<$Res>
+    extends _$PackageApiStorageV3CopyWithImpl<$Res, _$_PackageApiStorageV3>
     implements _$$_PackageApiStorageV3CopyWith<$Res> {
   __$$_PackageApiStorageV3CopyWithImpl(_$_PackageApiStorageV3 _value,
       $Res Function(_$_PackageApiStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_PackageApiStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_PackageApiStorageV3 get _value => super._value as _$_PackageApiStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? packageName = freezed,
+    Object? packageName = null,
     Object? packageVersion = freezed,
-    Object? packagePath = freezed,
-    Object? interfaceDeclarations = freezed,
-    Object? executableDeclarations = freezed,
-    Object? fieldDeclarations = freezed,
-    Object? typeAliasDeclarations = freezed,
-    Object? semantics = freezed,
+    Object? packagePath = null,
+    Object? interfaceDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
     Object? iosPlatformConstraints = freezed,
     Object? androidPlatformConstraints = freezed,
-    Object? sdkType = freezed,
-    Object? minSdkVersion = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
   }) {
     return _then(_$_PackageApiStorageV3(
-      packageName: packageName == freezed
+      packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
-      packageVersion: packageVersion == freezed
+      packageVersion: freezed == packageVersion
           ? _value.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
-      packagePath: packagePath == freezed
+      packagePath: null == packagePath
           ? _value.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
-      interfaceDeclarations: interfaceDeclarations == freezed
+      interfaceDeclarations: null == interfaceDeclarations
           ? _value._interfaceDeclarations
           : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
               as List<InterfaceDeclarationStorageV3>,
-      executableDeclarations: executableDeclarations == freezed
+      executableDeclarations: null == executableDeclarations
           ? _value._executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: fieldDeclarations == freezed
+      fieldDeclarations: null == fieldDeclarations
           ? _value._fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
-      typeAliasDeclarations: typeAliasDeclarations == freezed
+      typeAliasDeclarations: null == typeAliasDeclarations
           ? _value._typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclarationStorageV3>,
-      semantics: semantics == freezed
+      semantics: null == semantics
           ? _value._semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
-      iosPlatformConstraints: iosPlatformConstraints == freezed
+      iosPlatformConstraints: freezed == iosPlatformConstraints
           ? _value.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraintsStorageV3?,
-      androidPlatformConstraints: androidPlatformConstraints == freezed
+      androidPlatformConstraints: freezed == androidPlatformConstraints
           ? _value.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraintsStorageV3?,
-      sdkType: sdkType == freezed
+      sdkType: null == sdkType
           ? _value.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkTypeStorageV3,
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: null == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
@@ -367,12 +371,12 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_PackageApiStorageV3 &&
-            const DeepCollectionEquality()
-                .equals(other.packageName, packageName) &&
-            const DeepCollectionEquality()
-                .equals(other.packageVersion, packageVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.packagePath, packagePath) &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion) &&
+            (identical(other.packagePath, packagePath) ||
+                other.packagePath == packagePath) &&
             const DeepCollectionEquality()
                 .equals(other._interfaceDeclarations, _interfaceDeclarations) &&
             const DeepCollectionEquality().equals(
@@ -383,34 +387,37 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
                 .equals(other._typeAliasDeclarations, _typeAliasDeclarations) &&
             const DeepCollectionEquality()
                 .equals(other._semantics, _semantics) &&
-            const DeepCollectionEquality()
-                .equals(other.iosPlatformConstraints, iosPlatformConstraints) &&
-            const DeepCollectionEquality().equals(
-                other.androidPlatformConstraints, androidPlatformConstraints) &&
-            const DeepCollectionEquality().equals(other.sdkType, sdkType) &&
-            const DeepCollectionEquality()
-                .equals(other.minSdkVersion, minSdkVersion));
+            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
+                other.iosPlatformConstraints == iosPlatformConstraints) &&
+            (identical(other.androidPlatformConstraints,
+                    androidPlatformConstraints) ||
+                other.androidPlatformConstraints ==
+                    androidPlatformConstraints) &&
+            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(packageName),
-      const DeepCollectionEquality().hash(packageVersion),
-      const DeepCollectionEquality().hash(packagePath),
+      packageName,
+      packageVersion,
+      packagePath,
       const DeepCollectionEquality().hash(_interfaceDeclarations),
       const DeepCollectionEquality().hash(_executableDeclarations),
       const DeepCollectionEquality().hash(_fieldDeclarations),
       const DeepCollectionEquality().hash(_typeAliasDeclarations),
       const DeepCollectionEquality().hash(_semantics),
-      const DeepCollectionEquality().hash(iosPlatformConstraints),
-      const DeepCollectionEquality().hash(androidPlatformConstraints),
-      const DeepCollectionEquality().hash(sdkType),
-      const DeepCollectionEquality().hash(minSdkVersion));
+      iosPlatformConstraints,
+      androidPlatformConstraints,
+      sdkType,
+      minSdkVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_PackageApiStorageV3CopyWith<_$_PackageApiStorageV3> get copyWith =>
       __$$_PackageApiStorageV3CopyWithImpl<_$_PackageApiStorageV3>(
           this, _$identity);

--- a/lib/src/storage/v3/package_api_storage_v3.g.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.g.dart
@@ -14,9 +14,9 @@ _$_PackageApiStorageV3 _$$_PackageApiStorageV3FromJson(
       packageName: json['packageName'] as String,
       packageVersion: json['packageVersion'] as String?,
       packagePath: json['packagePath'] as String,
-      classDeclarations: (json['classDeclarations'] as List<dynamic>)
+      interfaceDeclarations: (json['interfaceDeclarations'] as List<dynamic>)
           .map((e) =>
-              ClassDeclarationStorageV3.fromJson(e as Map<String, dynamic>))
+              InterfaceDeclarationStorageV3.fromJson(e as Map<String, dynamic>))
           .toList(),
       executableDeclarations: (json['executableDeclarations'] as List<dynamic>)
           .map((e) => ExecutableDeclarationStorageV3.fromJson(
@@ -52,7 +52,7 @@ Map<String, dynamic> _$$_PackageApiStorageV3ToJson(
       'packageName': instance.packageName,
       'packageVersion': instance.packageVersion,
       'packagePath': instance.packagePath,
-      'classDeclarations': instance.classDeclarations,
+      'interfaceDeclarations': instance.interfaceDeclarations,
       'executableDeclarations': instance.executableDeclarations,
       'fieldDeclarations': instance.fieldDeclarations,
       'typeAliasDeclarations': instance.typeAliasDeclarations,

--- a/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
@@ -34,29 +34,34 @@ abstract class $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
   factory $IOSPlatformConstraintsStorageV3CopyWith(
           IOSPlatformConstraintsStorageV3 value,
           $Res Function(IOSPlatformConstraintsStorageV3) then) =
-      _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>;
+      _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
+          IOSPlatformConstraintsStorageV3>;
+  @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
-class _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
+class _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
+        $Val extends IOSPlatformConstraintsStorageV3>
     implements $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
   _$IOSPlatformConstraintsStorageV3CopyWithImpl(this._value, this._then);
 
-  final IOSPlatformConstraintsStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(IOSPlatformConstraintsStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minimumOsVersion: minimumOsVersion == freezed
+      minimumOsVersion: freezed == minimumOsVersion
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -68,28 +73,27 @@ abstract class _$$_IOSPlatformConstraintsStorageV3CopyWith<$Res>
           $Res Function(_$_IOSPlatformConstraintsStorageV3) then) =
       __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
 class __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
-    extends _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
+    extends _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
+        _$_IOSPlatformConstraintsStorageV3>
     implements _$$_IOSPlatformConstraintsStorageV3CopyWith<$Res> {
   __$$_IOSPlatformConstraintsStorageV3CopyWithImpl(
       _$_IOSPlatformConstraintsStorageV3 _value,
       $Res Function(_$_IOSPlatformConstraintsStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_IOSPlatformConstraintsStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_IOSPlatformConstraintsStorageV3 get _value =>
-      super._value as _$_IOSPlatformConstraintsStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_$_IOSPlatformConstraintsStorageV3(
-      minimumOsVersion: minimumOsVersion == freezed
+      minimumOsVersion: freezed == minimumOsVersion
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
@@ -121,17 +125,17 @@ class _$_IOSPlatformConstraintsStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_IOSPlatformConstraintsStorageV3 &&
-            const DeepCollectionEquality()
-                .equals(other.minimumOsVersion, minimumOsVersion));
+            (identical(other.minimumOsVersion, minimumOsVersion) ||
+                other.minimumOsVersion == minimumOsVersion));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(minimumOsVersion));
+  int get hashCode => Object.hash(runtimeType, minimumOsVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_IOSPlatformConstraintsStorageV3CopyWith<
           _$_IOSPlatformConstraintsStorageV3>
       get copyWith => __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<
@@ -187,20 +191,25 @@ abstract class $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
   factory $AndroidPlatformConstraintsStorageV3CopyWith(
           AndroidPlatformConstraintsStorageV3 value,
           $Res Function(AndroidPlatformConstraintsStorageV3) then) =
-      _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>;
+      _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
+          AndroidPlatformConstraintsStorageV3>;
+  @useResult
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
-class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
+class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
+        $Val extends AndroidPlatformConstraintsStorageV3>
     implements $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
   _$AndroidPlatformConstraintsStorageV3CopyWithImpl(this._value, this._then);
 
-  final AndroidPlatformConstraintsStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(AndroidPlatformConstraintsStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -208,19 +217,19 @@ class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: freezed == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: compileSdkVersion == freezed
+      compileSdkVersion: freezed == compileSdkVersion
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: targetSdkVersion == freezed
+      targetSdkVersion: freezed == targetSdkVersion
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-    ));
+    ) as $Val);
   }
 }
 
@@ -232,24 +241,22 @@ abstract class _$$_AndroidPlatformConstraintsStorageV3CopyWith<$Res>
           $Res Function(_$_AndroidPlatformConstraintsStorageV3) then) =
       __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
 class __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
-    extends _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
+    extends _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
+        _$_AndroidPlatformConstraintsStorageV3>
     implements _$$_AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
   __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl(
       _$_AndroidPlatformConstraintsStorageV3 _value,
       $Res Function(_$_AndroidPlatformConstraintsStorageV3) _then)
-      : super(
-            _value, (v) => _then(v as _$_AndroidPlatformConstraintsStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_AndroidPlatformConstraintsStorageV3 get _value =>
-      super._value as _$_AndroidPlatformConstraintsStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -257,15 +264,15 @@ class __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_$_AndroidPlatformConstraintsStorageV3(
-      minSdkVersion: minSdkVersion == freezed
+      minSdkVersion: freezed == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: compileSdkVersion == freezed
+      compileSdkVersion: freezed == compileSdkVersion
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: targetSdkVersion == freezed
+      targetSdkVersion: freezed == targetSdkVersion
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
@@ -304,24 +311,22 @@ class _$_AndroidPlatformConstraintsStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_AndroidPlatformConstraintsStorageV3 &&
-            const DeepCollectionEquality()
-                .equals(other.minSdkVersion, minSdkVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.compileSdkVersion, compileSdkVersion) &&
-            const DeepCollectionEquality()
-                .equals(other.targetSdkVersion, targetSdkVersion));
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion) &&
+            (identical(other.compileSdkVersion, compileSdkVersion) ||
+                other.compileSdkVersion == compileSdkVersion) &&
+            (identical(other.targetSdkVersion, targetSdkVersion) ||
+                other.targetSdkVersion == targetSdkVersion));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(minSdkVersion),
-      const DeepCollectionEquality().hash(compileSdkVersion),
-      const DeepCollectionEquality().hash(targetSdkVersion));
+      runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_AndroidPlatformConstraintsStorageV3CopyWith<
           _$_AndroidPlatformConstraintsStorageV3>
       get copyWith => __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<

--- a/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
@@ -34,34 +34,29 @@ abstract class $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
   factory $IOSPlatformConstraintsStorageV3CopyWith(
           IOSPlatformConstraintsStorageV3 value,
           $Res Function(IOSPlatformConstraintsStorageV3) then) =
-      _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
-          IOSPlatformConstraintsStorageV3>;
-  @useResult
+      _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>;
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
-class _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        $Val extends IOSPlatformConstraintsStorageV3>
+class _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
     implements $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
   _$IOSPlatformConstraintsStorageV3CopyWithImpl(this._value, this._then);
 
+  final IOSPlatformConstraintsStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(IOSPlatformConstraintsStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minimumOsVersion: freezed == minimumOsVersion
+      minimumOsVersion: minimumOsVersion == freezed
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
-    ) as $Val);
+    ));
   }
 }
 
@@ -73,27 +68,28 @@ abstract class _$$_IOSPlatformConstraintsStorageV3CopyWith<$Res>
           $Res Function(_$_IOSPlatformConstraintsStorageV3) then) =
       __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
 class __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
-    extends _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        _$_IOSPlatformConstraintsStorageV3>
+    extends _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
     implements _$$_IOSPlatformConstraintsStorageV3CopyWith<$Res> {
   __$$_IOSPlatformConstraintsStorageV3CopyWithImpl(
       _$_IOSPlatformConstraintsStorageV3 _value,
       $Res Function(_$_IOSPlatformConstraintsStorageV3) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_IOSPlatformConstraintsStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_IOSPlatformConstraintsStorageV3 get _value =>
+      super._value as _$_IOSPlatformConstraintsStorageV3;
+
   @override
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
     return _then(_$_IOSPlatformConstraintsStorageV3(
-      minimumOsVersion: freezed == minimumOsVersion
+      minimumOsVersion: minimumOsVersion == freezed
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
               as num?,
@@ -125,17 +121,17 @@ class _$_IOSPlatformConstraintsStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_IOSPlatformConstraintsStorageV3 &&
-            (identical(other.minimumOsVersion, minimumOsVersion) ||
-                other.minimumOsVersion == minimumOsVersion));
+            const DeepCollectionEquality()
+                .equals(other.minimumOsVersion, minimumOsVersion));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, minimumOsVersion);
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(minimumOsVersion));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_IOSPlatformConstraintsStorageV3CopyWith<
           _$_IOSPlatformConstraintsStorageV3>
       get copyWith => __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<
@@ -191,25 +187,20 @@ abstract class $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
   factory $AndroidPlatformConstraintsStorageV3CopyWith(
           AndroidPlatformConstraintsStorageV3 value,
           $Res Function(AndroidPlatformConstraintsStorageV3) then) =
-      _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
-          AndroidPlatformConstraintsStorageV3>;
-  @useResult
+      _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>;
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
-class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        $Val extends AndroidPlatformConstraintsStorageV3>
+class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
     implements $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
   _$AndroidPlatformConstraintsStorageV3CopyWithImpl(this._value, this._then);
 
+  final AndroidPlatformConstraintsStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(AndroidPlatformConstraintsStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -217,19 +208,19 @@ class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_value.copyWith(
-      minSdkVersion: freezed == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: freezed == compileSdkVersion
+      compileSdkVersion: compileSdkVersion == freezed
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: freezed == targetSdkVersion
+      targetSdkVersion: targetSdkVersion == freezed
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-    ) as $Val);
+    ));
   }
 }
 
@@ -241,22 +232,24 @@ abstract class _$$_AndroidPlatformConstraintsStorageV3CopyWith<$Res>
           $Res Function(_$_AndroidPlatformConstraintsStorageV3) then) =
       __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
 class __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
-    extends _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        _$_AndroidPlatformConstraintsStorageV3>
+    extends _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
     implements _$$_AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
   __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl(
       _$_AndroidPlatformConstraintsStorageV3 _value,
       $Res Function(_$_AndroidPlatformConstraintsStorageV3) _then)
-      : super(_value, _then);
+      : super(
+            _value, (v) => _then(v as _$_AndroidPlatformConstraintsStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_AndroidPlatformConstraintsStorageV3 get _value =>
+      super._value as _$_AndroidPlatformConstraintsStorageV3;
+
   @override
   $Res call({
     Object? minSdkVersion = freezed,
@@ -264,15 +257,15 @@ class __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
     Object? targetSdkVersion = freezed,
   }) {
     return _then(_$_AndroidPlatformConstraintsStorageV3(
-      minSdkVersion: freezed == minSdkVersion
+      minSdkVersion: minSdkVersion == freezed
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      compileSdkVersion: freezed == compileSdkVersion
+      compileSdkVersion: compileSdkVersion == freezed
           ? _value.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
-      targetSdkVersion: freezed == targetSdkVersion
+      targetSdkVersion: targetSdkVersion == freezed
           ? _value.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
@@ -311,22 +304,24 @@ class _$_AndroidPlatformConstraintsStorageV3
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_AndroidPlatformConstraintsStorageV3 &&
-            (identical(other.minSdkVersion, minSdkVersion) ||
-                other.minSdkVersion == minSdkVersion) &&
-            (identical(other.compileSdkVersion, compileSdkVersion) ||
-                other.compileSdkVersion == compileSdkVersion) &&
-            (identical(other.targetSdkVersion, targetSdkVersion) ||
-                other.targetSdkVersion == targetSdkVersion));
+            const DeepCollectionEquality()
+                .equals(other.minSdkVersion, minSdkVersion) &&
+            const DeepCollectionEquality()
+                .equals(other.compileSdkVersion, compileSdkVersion) &&
+            const DeepCollectionEquality()
+                .equals(other.targetSdkVersion, targetSdkVersion));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-      runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
+      runtimeType,
+      const DeepCollectionEquality().hash(minSdkVersion),
+      const DeepCollectionEquality().hash(compileSdkVersion),
+      const DeepCollectionEquality().hash(targetSdkVersion));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_AndroidPlatformConstraintsStorageV3CopyWith<
           _$_AndroidPlatformConstraintsStorageV3>
       get copyWith => __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<

--- a/lib/src/storage/v3/storage_v3.dart
+++ b/lib/src/storage/v3/storage_v3.dart
@@ -1,5 +1,5 @@
 export 'package_api_storage_v3.dart';
-export 'class_declaration_storage_v3.dart';
+export 'interface_declaration_storage_v3.dart';
 export 'executable_declaration_storage_v3.dart';
 export 'field_declaration_storage_v3.dart';
 export 'type_alias_declaration_storage_v3.dart';

--- a/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
@@ -37,9 +37,7 @@ abstract class $TypeAliasDeclarationStorageV3CopyWith<$Res> {
   factory $TypeAliasDeclarationStorageV3CopyWith(
           TypeAliasDeclarationStorageV3 value,
           $Res Function(TypeAliasDeclarationStorageV3) then) =
-      _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
-          TypeAliasDeclarationStorageV3>;
-  @useResult
+      _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>;
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -48,42 +46,39 @@ abstract class $TypeAliasDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends TypeAliasDeclarationStorageV3>
+class _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
     implements $TypeAliasDeclarationStorageV3CopyWith<$Res> {
   _$TypeAliasDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
+  final TypeAliasDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final $Res Function(TypeAliasDeclarationStorageV3) _then;
 
-  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = null,
-    Object? aliasedTypeName = null,
-    Object? isDeprecated = null,
-    Object? entryPoints = null,
+    Object? name = freezed,
+    Object? aliasedTypeName = freezed,
+    Object? isDeprecated = freezed,
+    Object? entryPoints = freezed,
   }) {
     return _then(_value.copyWith(
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: null == aliasedTypeName
+      aliasedTypeName: aliasedTypeName == freezed
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ) as $Val);
+    ));
   }
 }
 
@@ -95,7 +90,6 @@ abstract class _$$_TypeAliasDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_TypeAliasDeclarationStorageV3) then) =
       __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>;
   @override
-  @useResult
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -105,36 +99,38 @@ abstract class _$$_TypeAliasDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
-        _$_TypeAliasDeclarationStorageV3>
+    extends _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
     implements _$$_TypeAliasDeclarationStorageV3CopyWith<$Res> {
   __$$_TypeAliasDeclarationStorageV3CopyWithImpl(
       _$_TypeAliasDeclarationStorageV3 _value,
       $Res Function(_$_TypeAliasDeclarationStorageV3) _then)
-      : super(_value, _then);
+      : super(_value, (v) => _then(v as _$_TypeAliasDeclarationStorageV3));
 
-  @pragma('vm:prefer-inline')
+  @override
+  _$_TypeAliasDeclarationStorageV3 get _value =>
+      super._value as _$_TypeAliasDeclarationStorageV3;
+
   @override
   $Res call({
-    Object? name = null,
-    Object? aliasedTypeName = null,
-    Object? isDeprecated = null,
-    Object? entryPoints = null,
+    Object? name = freezed,
+    Object? aliasedTypeName = freezed,
+    Object? isDeprecated = freezed,
+    Object? entryPoints = freezed,
   }) {
     return _then(_$_TypeAliasDeclarationStorageV3(
-      name: null == name
+      name: name == freezed
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: null == aliasedTypeName
+      aliasedTypeName: aliasedTypeName == freezed
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: null == isDeprecated
+      isDeprecated: isDeprecated == freezed
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: null == entryPoints
+      entryPoints: entryPoints == freezed
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -180,23 +176,26 @@ class _$_TypeAliasDeclarationStorageV3 extends _TypeAliasDeclarationStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_TypeAliasDeclarationStorageV3 &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.aliasedTypeName, aliasedTypeName) ||
-                other.aliasedTypeName == aliasedTypeName) &&
-            (identical(other.isDeprecated, isDeprecated) ||
-                other.isDeprecated == isDeprecated) &&
+            const DeepCollectionEquality().equals(other.name, name) &&
+            const DeepCollectionEquality()
+                .equals(other.aliasedTypeName, aliasedTypeName) &&
+            const DeepCollectionEquality()
+                .equals(other.isDeprecated, isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, name, aliasedTypeName,
-      isDeprecated, const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(name),
+      const DeepCollectionEquality().hash(aliasedTypeName),
+      const DeepCollectionEquality().hash(isDeprecated),
+      const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
-  @pragma('vm:prefer-inline')
   _$$_TypeAliasDeclarationStorageV3CopyWith<_$_TypeAliasDeclarationStorageV3>
       get copyWith => __$$_TypeAliasDeclarationStorageV3CopyWithImpl<
           _$_TypeAliasDeclarationStorageV3>(this, _$identity);

--- a/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
@@ -37,7 +37,9 @@ abstract class $TypeAliasDeclarationStorageV3CopyWith<$Res> {
   factory $TypeAliasDeclarationStorageV3CopyWith(
           TypeAliasDeclarationStorageV3 value,
           $Res Function(TypeAliasDeclarationStorageV3) then) =
-      _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>;
+      _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
+          TypeAliasDeclarationStorageV3>;
+  @useResult
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -46,39 +48,42 @@ abstract class $TypeAliasDeclarationStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
+class _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
+        $Val extends TypeAliasDeclarationStorageV3>
     implements $TypeAliasDeclarationStorageV3CopyWith<$Res> {
   _$TypeAliasDeclarationStorageV3CopyWithImpl(this._value, this._then);
 
-  final TypeAliasDeclarationStorageV3 _value;
   // ignore: unused_field
-  final $Res Function(TypeAliasDeclarationStorageV3) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? aliasedTypeName = freezed,
-    Object? isDeprecated = freezed,
-    Object? entryPoints = freezed,
+    Object? name = null,
+    Object? aliasedTypeName = null,
+    Object? isDeprecated = null,
+    Object? entryPoints = null,
   }) {
     return _then(_value.copyWith(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: aliasedTypeName == freezed
+      aliasedTypeName: null == aliasedTypeName
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
-    ));
+    ) as $Val);
   }
 }
 
@@ -90,6 +95,7 @@ abstract class _$$_TypeAliasDeclarationStorageV3CopyWith<$Res>
           $Res Function(_$_TypeAliasDeclarationStorageV3) then) =
       __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String name,
       String aliasedTypeName,
@@ -99,38 +105,36 @@ abstract class _$$_TypeAliasDeclarationStorageV3CopyWith<$Res>
 
 /// @nodoc
 class __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
-    extends _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
+    extends _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
+        _$_TypeAliasDeclarationStorageV3>
     implements _$$_TypeAliasDeclarationStorageV3CopyWith<$Res> {
   __$$_TypeAliasDeclarationStorageV3CopyWithImpl(
       _$_TypeAliasDeclarationStorageV3 _value,
       $Res Function(_$_TypeAliasDeclarationStorageV3) _then)
-      : super(_value, (v) => _then(v as _$_TypeAliasDeclarationStorageV3));
+      : super(_value, _then);
 
-  @override
-  _$_TypeAliasDeclarationStorageV3 get _value =>
-      super._value as _$_TypeAliasDeclarationStorageV3;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? aliasedTypeName = freezed,
-    Object? isDeprecated = freezed,
-    Object? entryPoints = freezed,
+    Object? name = null,
+    Object? aliasedTypeName = null,
+    Object? isDeprecated = null,
+    Object? entryPoints = null,
   }) {
     return _then(_$_TypeAliasDeclarationStorageV3(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      aliasedTypeName: aliasedTypeName == freezed
+      aliasedTypeName: null == aliasedTypeName
           ? _value.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
-      isDeprecated: isDeprecated == freezed
+      isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
-      entryPoints: entryPoints == freezed
+      entryPoints: null == entryPoints
           ? _value._entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
@@ -176,26 +180,23 @@ class _$_TypeAliasDeclarationStorageV3 extends _TypeAliasDeclarationStorageV3 {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_TypeAliasDeclarationStorageV3 &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.aliasedTypeName, aliasedTypeName) &&
-            const DeepCollectionEquality()
-                .equals(other.isDeprecated, isDeprecated) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.aliasedTypeName, aliasedTypeName) ||
+                other.aliasedTypeName == aliasedTypeName) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
             const DeepCollectionEquality()
                 .equals(other._entryPoints, _entryPoints));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(aliasedTypeName),
-      const DeepCollectionEquality().hash(isDeprecated),
-      const DeepCollectionEquality().hash(_entryPoints));
+  int get hashCode => Object.hash(runtimeType, name, aliasedTypeName,
+      isDeprecated, const DeepCollectionEquality().hash(_entryPoints));
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_TypeAliasDeclarationStorageV3CopyWith<_$_TypeAliasDeclarationStorageV3>
       get copyWith => __$$_TypeAliasDeclarationStorageV3CopyWithImpl<
           _$_TypeAliasDeclarationStorageV3>(this, _$identity);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A tool to analyze the public API of a package, create a model of it
 homepage: https://devmil.de
 repository: https://github.com/devmil/dart_apitool
 
-version: 0.6.1-dev
+version: 0.7.0-dev
 
 environment:
   sdk: ">=2.17.5 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,15 +8,15 @@ version: 0.6.1-dev
 environment:
   sdk: ">=2.17.5 <3.0.0"
 
-dependencies: 
-  analyzer: ^4.3.1
+dependencies:
+  analyzer: ^5.1.0
   args: ^2.3.1
   collection: ^1.16.0
   colorize: ^3.0.0
   colorize_lumberdash: ^3.0.0
   console: ^4.1.0
   freezed_annotation: ^2.1.0
-  json_annotation: ^4.6.0
+  json_annotation: ^4.7.0
   lumberdash: ^3.0.0
   path: ^1.8.2
   plist_parser: ^0.0.9
@@ -26,13 +26,13 @@ dependencies:
   tuple: ^2.0.0
   yaml: ^3.1.1
 
-dev_dependencies: 
+dev_dependencies:
   build_runner: ^2.2.0
   flutter_lints: ^2.0.1
   freezed: ^2.1.0+1
   json_serializable: ^6.3.1
   lints: ^2.0.0
   test: ^1.21.4
- 
+
 executables:
   dart-apitool: main

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   colorize: ^3.0.0
   colorize_lumberdash: ^3.0.0
   console: ^4.1.0
-  freezed_annotation: ^2.1.0
+  freezed_annotation: ^2.2.0
   json_annotation: ^4.7.0
   lumberdash: ^3.0.0
   path: ^1.8.2
@@ -29,7 +29,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.2.0
   flutter_lints: ^2.0.1
-  freezed: ^2.1.0+1
+  freezed: ^2.2.0
   json_serializable: ^6.3.1
   lints: ^2.0.0
   test: ^1.21.4

--- a/test/integration_tests/analyze/bloc_test.dart
+++ b/test/integration_tests/analyze/bloc_test.dart
@@ -15,7 +15,7 @@ void main() {
     });
 
     test('Bloc class is available', () {
-      final blocClass = packageApi.classDeclarations
+      final blocClass = packageApi.interfaceDeclarations
           .singleWhere((element) => element.name == 'Bloc');
 
       expect(blocClass.name, 'Bloc');
@@ -26,7 +26,7 @@ void main() {
       expect(stateField.typeName, 'State');
     });
     test('Transition class is available', () {
-      final transitionClass = packageApi.classDeclarations
+      final transitionClass = packageApi.interfaceDeclarations
           .singleWhere((element) => element.name == 'Transition');
 
       expect(transitionClass.name, 'Transition');

--- a/test/integration_tests/analyze/device_info_plus_test.dart
+++ b/test/integration_tests/analyze/device_info_plus_test.dart
@@ -21,7 +21,7 @@ void main() {
       expect(packageApi.packageVersion, '2.4.0');
     });
     void testField(
-      ClassDeclaration Function() getHostClass,
+      InterfaceDeclaration Function() getHostClass,
       String fieldName, {
       required String expectedTypeName,
       required bool expectedIsDeprecatedFlag,
@@ -38,7 +38,7 @@ void main() {
     group('WindowsDevice is analyzed correctly', () {
       // ignore: prefer_function_declarations_over_variables
       final getHostClass = () {
-        return packageApi.classDeclarations
+        return packageApi.interfaceDeclarations
             .firstWhere((element) => element.name == 'WindowsDeviceInfo');
       };
       testField(getHostClass, 'computerName',
@@ -71,7 +71,7 @@ void main() {
     group('AndroidDeviceInfo is analyzed correctly', () {
       // ignore: prefer_function_declarations_over_variables
       final getHostClass = () {
-        return packageApi.classDeclarations
+        return packageApi.interfaceDeclarations
             .firstWhere((element) => element.name == 'AndroidDeviceInfo');
       };
       testField(getHostClass, 'board',
@@ -114,7 +114,7 @@ void main() {
         // MethodChannelDeviceInfo gets used in the implementation but is not exposed directly or indirectly via
         // any signatures => not part of the public API
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'MethodChannelDeviceInfo')
                 .isEmpty,
             isTrue);
@@ -123,7 +123,7 @@ void main() {
         // PlatformInterface is used as a super class for DeviceInfoPlatform but does not belong to this package
         // => it is not part of the public API
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'PlatformInterface')
                 .isEmpty,
             isTrue);
@@ -131,56 +131,56 @@ void main() {
 
       test('DeviceInfoPlatform is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'DeviceInfoPlatform')
                 .isNotEmpty,
             isTrue);
       });
       test('BaseDeviceInfo is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'BaseDeviceInfo')
                 .isNotEmpty,
             isTrue);
       });
       test('WebBrowserInfo is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'WebBrowserInfo')
                 .isNotEmpty,
             isTrue);
       });
       test('MacOsDeviceInfo is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'MacOsDeviceInfo')
                 .isNotEmpty,
             isTrue);
       });
       test('WindowsDeviceInfo is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'WindowsDeviceInfo')
                 .isNotEmpty,
             isTrue);
       });
       test('LinuxDeviceInfo is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'LinuxDeviceInfo')
                 .isNotEmpty,
             isTrue);
       });
       test('IosDeviceInfo is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'IosDeviceInfo')
                 .isNotEmpty,
             isTrue);
       });
       test('AndroidDeviceInfo is part of the public API', () {
         expect(
-            packageApi.classDeclarations
+            packageApi.interfaceDeclarations
                 .where((element) => element.name == 'AndroidDeviceInfo')
                 .isNotEmpty,
             isTrue);

--- a/test/integration_tests/analyze/flutter_blue_test.dart
+++ b/test/integration_tests/analyze/flutter_blue_test.dart
@@ -16,34 +16,36 @@ void main() {
 
     test('BluetoothCharacteristic exists two times in different namespaces',
         () {
-      final bluetoothCharacteristicClasses = packageApi.classDeclarations
+      final bluetoothCharacteristicClasses = packageApi.interfaceDeclarations
           .where((element) => element.name.endsWith('BluetoothCharacteristic'))
           .toList();
 
       expect(bluetoothCharacteristicClasses.length, 2);
 
-      final bluetoothCharacteristicMainClasses = packageApi.classDeclarations
+      final bluetoothCharacteristicMainClasses = packageApi
+          .interfaceDeclarations
           .where((element) => element.name == 'BluetoothCharacteristic')
           .toList();
       expect(bluetoothCharacteristicMainClasses.length, 1);
-      final bluetoothCharacteristicProtoClasses = packageApi.classDeclarations
+      final bluetoothCharacteristicProtoClasses = packageApi
+          .interfaceDeclarations
           .where((element) => element.name == 'protos.BluetoothCharacteristic')
           .toList();
       expect(bluetoothCharacteristicProtoClasses.length, 1);
     });
 
     test('ScanResult exists two times in different namespaces', () {
-      final scanResultClasses = packageApi.classDeclarations
+      final scanResultClasses = packageApi.interfaceDeclarations
           .where((element) => element.name.endsWith('ScanResult'))
           .toList();
 
       expect(scanResultClasses.length, 2);
 
-      final scanResultMainClasses = packageApi.classDeclarations
+      final scanResultMainClasses = packageApi.interfaceDeclarations
           .where((element) => element.name == 'ScanResult')
           .toList();
       expect(scanResultMainClasses.length, 1);
-      final scanResultProtoClasses = packageApi.classDeclarations
+      final scanResultProtoClasses = packageApi.interfaceDeclarations
           .where((element) => element.name == 'protos.ScanResult')
           .toList();
       expect(scanResultProtoClasses.length, 1);

--- a/test/package_api_differ_test.dart
+++ b/test/package_api_differ_test.dart
@@ -24,7 +24,8 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 1);
       final newClassApiChange = diffResult.apiChanges.first;
-      expect(newClassApiChange.affectedDeclaration, isA<ClassDeclaration>());
+      expect(
+          newClassApiChange.affectedDeclaration, isA<InterfaceDeclaration>());
       expect(newClassApiChange.type, ApiChangeType.addCompatible);
       expect(newClassApiChange.changeDescription, contains('ClassB'));
       expect(newClassApiChange.contextTrace, isEmpty);
@@ -37,8 +38,8 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 1);
       final removedClassApiChange = diffResult.apiChanges.first;
-      expect(
-          removedClassApiChange.affectedDeclaration, isA<ClassDeclaration>());
+      expect(removedClassApiChange.affectedDeclaration,
+          isA<InterfaceDeclaration>());
       expect(removedClassApiChange.type, ApiChangeType.remove);
       expect(removedClassApiChange.changeDescription, contains('ClassB'));
       expect(removedClassApiChange.contextTrace, isEmpty);
@@ -110,9 +111,10 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 1);
       final deprecatedAddedChange = diffResult.apiChanges.first;
-      expect(
-          deprecatedAddedChange.affectedDeclaration, isA<ClassDeclaration>());
-      expect(deprecatedAddedChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(deprecatedAddedChange.affectedDeclaration,
+          isA<InterfaceDeclaration>());
+      expect(deprecatedAddedChange.contextTrace.first,
+          isA<InterfaceDeclaration>());
       expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
@@ -124,9 +126,10 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 1);
       final deprecatedAddedChange = diffResult.apiChanges.first;
-      expect(
-          deprecatedAddedChange.affectedDeclaration, isA<ClassDeclaration>());
-      expect(deprecatedAddedChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(deprecatedAddedChange.affectedDeclaration,
+          isA<InterfaceDeclaration>());
+      expect(deprecatedAddedChange.contextTrace.first,
+          isA<InterfaceDeclaration>());
       expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
@@ -216,9 +219,9 @@ void main() {
       expect(diffResult.apiChanges.length, 1);
       final typeParameterAddedChange = diffResult.apiChanges.first;
       expect(typeParameterAddedChange.affectedDeclaration,
-          isA<ClassDeclaration>());
-      expect(
-          typeParameterAddedChange.contextTrace.first, isA<ClassDeclaration>());
+          isA<InterfaceDeclaration>());
+      expect(typeParameterAddedChange.contextTrace.first,
+          isA<InterfaceDeclaration>());
       expect(typeParameterAddedChange.type, ApiChangeType.addBreaking);
       expect(typeParameterAddedChange.changeDescription,
           contains('Type Parameter "T"'));
@@ -236,9 +239,9 @@ void main() {
       expect(diffResult.apiChanges.length, 1);
       final typeParameterRemovedChange = diffResult.apiChanges.first;
       expect(typeParameterRemovedChange.affectedDeclaration,
-          isA<ClassDeclaration>());
+          isA<InterfaceDeclaration>());
       expect(typeParameterRemovedChange.contextTrace.first,
-          isA<ClassDeclaration>());
+          isA<InterfaceDeclaration>());
       expect(typeParameterRemovedChange.type, ApiChangeType.remove);
       expect(typeParameterRemovedChange.changeDescription,
           contains('Type Parameter "T"'));
@@ -301,17 +304,17 @@ void main() {
       final typeParmeterRemovedChange = diffResult.apiChanges
           .where((change) => change.type == ApiChangeType.remove)
           .single;
-      expect(
-          typeParmeterAddedChange.affectedDeclaration, isA<ClassDeclaration>());
-      expect(
-          typeParmeterAddedChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(typeParmeterAddedChange.affectedDeclaration,
+          isA<InterfaceDeclaration>());
+      expect(typeParmeterAddedChange.contextTrace.first,
+          isA<InterfaceDeclaration>());
       expect(typeParmeterAddedChange.type, ApiChangeType.addBreaking);
       expect(typeParmeterAddedChange.changeDescription,
           contains('Type Parameter "R"'));
       expect(typeParmeterRemovedChange.affectedDeclaration,
-          isA<ClassDeclaration>());
+          isA<InterfaceDeclaration>());
       expect(typeParmeterRemovedChange.contextTrace.first,
-          isA<ClassDeclaration>());
+          isA<InterfaceDeclaration>());
       expect(typeParmeterRemovedChange.type, ApiChangeType.remove);
       expect(typeParmeterRemovedChange.changeDescription,
           contains('Type Parameter "T"'));
@@ -362,9 +365,10 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 1);
       final deprecatedAddedChange = diffResult.apiChanges.first;
-      expect(
-          deprecatedAddedChange.affectedDeclaration, isA<ClassDeclaration>());
-      expect(deprecatedAddedChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(deprecatedAddedChange.affectedDeclaration,
+          isA<InterfaceDeclaration>());
+      expect(deprecatedAddedChange.contextTrace.first,
+          isA<InterfaceDeclaration>());
       expect(deprecatedAddedChange.type, ApiChangeType.addBreaking);
       expect(deprecatedAddedChange.changeDescription, contains('"T"'));
     });
@@ -382,9 +386,10 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 1);
       final deprecatedAddedChange = diffResult.apiChanges.first;
-      expect(
-          deprecatedAddedChange.affectedDeclaration, isA<ClassDeclaration>());
-      expect(deprecatedAddedChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(deprecatedAddedChange.affectedDeclaration,
+          isA<InterfaceDeclaration>());
+      expect(deprecatedAddedChange.contextTrace.first,
+          isA<InterfaceDeclaration>());
       expect(deprecatedAddedChange.type, ApiChangeType.remove);
       expect(deprecatedAddedChange.changeDescription, contains('"T"'));
     });
@@ -724,16 +729,16 @@ void main() {
           (element) => element.type == ApiChangeType.addCompatible);
       final removeChange = diffResult.apiChanges
           .singleWhere((element) => element.type == ApiChangeType.remove);
-      expect(removeChange.affectedDeclaration, isA<ClassDeclaration>());
+      expect(removeChange.affectedDeclaration, isA<InterfaceDeclaration>());
       expect(removeChange.changeDescription, contains('Entry point'));
       expect(removeChange.changeDescription, contains('a.dart'));
-      expect(removeChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(removeChange.contextTrace.first, isA<InterfaceDeclaration>());
       expect(removeChange.type, ApiChangeType.remove);
 
-      expect(addChange.affectedDeclaration, isA<ClassDeclaration>());
+      expect(addChange.affectedDeclaration, isA<InterfaceDeclaration>());
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
-      expect(addChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(addChange.contextTrace.first, isA<InterfaceDeclaration>());
       expect(addChange.type, ApiChangeType.addCompatible);
     });
     test('EntryPoint add in class detected', () {
@@ -745,10 +750,10 @@ void main() {
       expect(diffResult.apiChanges.length, 1);
       final addChange = diffResult.apiChanges.single;
 
-      expect(addChange.affectedDeclaration, isA<ClassDeclaration>());
+      expect(addChange.affectedDeclaration, isA<InterfaceDeclaration>());
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
-      expect(addChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(addChange.contextTrace.first, isA<InterfaceDeclaration>());
       expect(addChange.type, ApiChangeType.addCompatible);
     });
     test('EntryPoint remove in class detected', () {
@@ -760,10 +765,10 @@ void main() {
       expect(diffResult.apiChanges.length, 1);
       final removeChange = diffResult.apiChanges.single;
 
-      expect(removeChange.affectedDeclaration, isA<ClassDeclaration>());
+      expect(removeChange.affectedDeclaration, isA<InterfaceDeclaration>());
       expect(removeChange.changeDescription, contains('Entry point'));
       expect(removeChange.changeDescription, contains('a.dart'));
-      expect(removeChange.contextTrace.first, isA<ClassDeclaration>());
+      expect(removeChange.contextTrace.first, isA<InterfaceDeclaration>());
       expect(removeChange.type, ApiChangeType.remove);
     });
   });

--- a/test/package_api_differ_test_data.dart
+++ b/test/package_api_differ_test_data.dart
@@ -1,6 +1,6 @@
 part of 'package_api_differ_test.dart';
 
-final simpleClassA = ClassDeclaration(
+final simpleClassA = InterfaceDeclaration(
   name: 'ClassA',
   isDeprecated: false,
   typeParameterNames: const [],
@@ -18,7 +18,7 @@ final simpleClassA = ClassDeclaration(
   ],
   fieldDeclarations: const [],
 );
-final simpleClassB = ClassDeclaration(
+final simpleClassB = InterfaceDeclaration(
   name: 'ClassB',
   isDeprecated: false,
   typeParameterNames: const [],
@@ -41,7 +41,7 @@ final packageClassAApi = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: [
+  interfaceDeclarations: [
     simpleClassA,
   ],
   executableDeclarations: const [],
@@ -52,17 +52,17 @@ final packageClassAApi = PackageApi(
 );
 // Package ClassA variations
 final packageClassADeprecatedApi = packageClassAApi.copyWith(
-  classDeclarations: packageClassAApi.classDeclarations
+  interfaceDeclarations: packageClassAApi.interfaceDeclarations
       .map((cd) => cd.copyWith(isDeprecated: true))
       .toList(),
 );
 final packageClassAWithTypeParameterTApi = packageClassAApi.copyWith(
-  classDeclarations: packageClassAApi.classDeclarations
+  interfaceDeclarations: packageClassAApi.interfaceDeclarations
       .map((cd) => cd.copyWith(typeParameterNames: ['T']))
       .toList(),
 );
 final packageClassAWithTypeParameterRApi = packageClassAApi.copyWith(
-  classDeclarations: packageClassAApi.classDeclarations
+  interfaceDeclarations: packageClassAApi.interfaceDeclarations
       .map((cd) => cd.copyWith(typeParameterNames: ['R']))
       .toList(),
 );
@@ -70,7 +70,7 @@ final packageClassAApiEntryPointA = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: [
+  interfaceDeclarations: [
     simpleClassA.copyWith(
       entryPoints: {
         'a.dart',
@@ -87,7 +87,7 @@ final packageClassAApiEntryPointB = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: [
+  interfaceDeclarations: [
     simpleClassA.copyWith(
       entryPoints: {
         'b.dart',
@@ -104,7 +104,7 @@ final packageClassAApiEntryPointAB = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: [
+  interfaceDeclarations: [
     simpleClassA.copyWith(
       entryPoints: {
         'a.dart',
@@ -124,7 +124,7 @@ final packageClassAClassBApi = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: [
+  interfaceDeclarations: [
     simpleClassA,
     simpleClassB,
   ],
@@ -166,7 +166,7 @@ final packageExecutable1Api = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: [
     simpleExecutable1,
   ],
@@ -299,7 +299,7 @@ final packageExecutable1ApiEntryPointA = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: [
     simpleExecutable1.copyWith(
       entryPoints: {
@@ -316,7 +316,7 @@ final packageExecutable1ApiEntryPointB = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: [
     simpleExecutable1.copyWith(
       entryPoints: {
@@ -333,7 +333,7 @@ final packageExecutable1ApiEntryPointAB = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: [
     simpleExecutable1.copyWith(
       entryPoints: {
@@ -353,7 +353,7 @@ final packageExecutable1Executable2Api = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: [
     simpleExecutable1,
     simpleExecutable2,
@@ -381,7 +381,7 @@ final packageFieldA = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: const [],
   fieldDeclarations: [
     simpleFieldDeclarationA,
@@ -406,7 +406,7 @@ final packageFieldAEntryPointA = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: const [],
   fieldDeclarations: [
     simpleFieldDeclarationA.copyWith(
@@ -423,7 +423,7 @@ final packageFieldAEntryPointB = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: const [],
   fieldDeclarations: [
     simpleFieldDeclarationA.copyWith(
@@ -440,7 +440,7 @@ final packageFieldAEntryPointAB = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: const [],
   fieldDeclarations: [
     simpleFieldDeclarationA.copyWith(
@@ -460,7 +460,7 @@ final packageFieldAFieldB = PackageApi(
   packageName: 'simple_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: const [],
+  interfaceDeclarations: const [],
   executableDeclarations: const [],
   fieldDeclarations: [
     simpleFieldDeclarationA,

--- a/test/package_api_storage_test.dart
+++ b/test/package_api_storage_test.dart
@@ -17,16 +17,16 @@ void main() {
       expect(packageApiJson['packageName'], 'storage_test_package');
       expect(packageApiJson['packageVersion'], '1.0.0');
       expect(packageApiJson['packagePath'], '.');
-      final classDeclarationsJson = packageApiJson['classDeclarations'];
-      expect(classDeclarationsJson, isNotNull);
-      final classDeclarationJson = classDeclarationsJson.first;
-      expect(classDeclarationJson, isNotNull);
-      expect(classDeclarationJson['name'], 'StorageTestClass');
-      expect(classDeclarationJson['isDeprecated'], false);
-      expect(classDeclarationJson['typeParameterNames'], ['T']);
-      expect(classDeclarationJson['superTypeNames'], ['SuperType']);
+      final interfaceDeclarationsJson = packageApiJson['interfaceDeclarations'];
+      expect(interfaceDeclarationsJson, isNotNull);
+      final interfaceDeclarationJson = interfaceDeclarationsJson.first;
+      expect(interfaceDeclarationJson, isNotNull);
+      expect(interfaceDeclarationJson['name'], 'StorageTestClass');
+      expect(interfaceDeclarationJson['isDeprecated'], false);
+      expect(interfaceDeclarationJson['typeParameterNames'], ['T']);
+      expect(interfaceDeclarationJson['superTypeNames'], ['SuperType']);
       final classExecutableDeclarationsJson =
-          classDeclarationJson['executableDeclarations'];
+          interfaceDeclarationJson['executableDeclarations'];
       expect(classExecutableDeclarationsJson, isNotNull);
       final classExecutableDeclaration = classExecutableDeclarationsJson.first;
       expect(classExecutableDeclaration, isNotNull);
@@ -56,7 +56,8 @@ void main() {
       expect(secondExecutableParameterDeclaration['name'], 'mode');
       expect(secondExecutableParameterDeclaration['isDeprecated'], false);
       expect(secondExecutableParameterDeclaration['typeName'], 'GetStringMode');
-      final classFieldDeclarations = classDeclarationJson['fieldDeclarations'];
+      final classFieldDeclarations =
+          interfaceDeclarationJson['fieldDeclarations'];
       expect(classFieldDeclarations, isNotNull);
       final classFieldDeclaration = classFieldDeclarations.first;
       expect(classFieldDeclaration, isNotNull);
@@ -80,8 +81,8 @@ final testPackage1Api = PackageApi(
   packageName: 'storage_test_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: [
-    ClassDeclaration(
+  interfaceDeclarations: [
+    InterfaceDeclaration(
       name: 'StorageTestClass',
       isDeprecated: false,
       typeParameterNames: const ['T'],
@@ -135,7 +136,7 @@ final package1JsonString = '''
         "packageName": "storage_test_package",
         "packageVersion": "1.0.0",
         "packagePath": ".",
-        "classDeclarations": [
+        "interfaceDeclarations": [
             {
                 "name": "StorageTestClass",
                 "isDeprecated": false,
@@ -193,8 +194,8 @@ final testPackage2Api = PackageApi(
   packageName: 'storage_test_package',
   packageVersion: '1.0.0',
   packagePath: '.',
-  classDeclarations: [
-    ClassDeclaration(
+  interfaceDeclarations: [
+    InterfaceDeclaration(
       name: 'StorageTestClass',
       isDeprecated: false,
       typeParameterNames: const ['T'],
@@ -261,7 +262,7 @@ final package2JsonString = '''
         "packageName": "storage_test_package",
         "packageVersion": "1.0.0",
         "packagePath": ".",
-        "classDeclarations": [
+        "interfaceDeclarations": [
             {
                 "name": "StorageTestClass",
                 "isDeprecated": false,


### PR DESCRIPTION
Extensions were ignored but everything they declare was extracted and put on root level.
This is a problem if multiple extensions declare things with the same name.

This PR treats extensions like Classes so everything they declare has its own scope