### PR TITLE
ignore unmatched elements

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.3.5",
+  "flutterSdkVersion": "3.3.7",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.7.1
+- improves handling of elements without root
+
 ## Version 0.7.0
 - *BREAKING*: renamed "Class" model elements to "Interface" to reflect the abstraction it represents
 - Fixes Extension handling (are now treated as interfaces)

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -277,18 +277,14 @@ class PackageApiAnalyzer {
             .addAll(entry.fieldDeclarations.map((e) => e.toFieldDeclaration()));
       } else if (interfaceId != null) {
         // here we collected an element in the context of a class but the class is not available
-        // in this case we add the elements to the root level and print a warning
+        // in this case we print a warning and ignore them
+        final executableList =
+            entry.executableDeclarations.map((e) => e.name).join(', ');
+        final fieldList = entry.fieldDeclarations.map((e) => e.name).join(', ');
+        final typeAliasList =
+            entry.typeAliasDeclarations.map((e) => e.name).join(', ');
         logWarning(
-            'We encountered elements that are marked to belong to an interface but the interface is not collected!');
-        collectedInterfaces[null]!
-            .executableDeclarations
-            .addAll(entry.executableDeclarations);
-        collectedInterfaces[null]!
-            .fieldDeclarations
-            .addAll(entry.fieldDeclarations);
-        collectedInterfaces[null]!
-            .typeAliasDeclarations
-            .addAll(entry.typeAliasDeclarations);
+            'We encountered elements that are marked to belong to an interface but the interface is not collected!\nExecutables: $executableList\nFields: $fieldList\nTypeAliases: $typeAliasList');
       }
     }
 

--- a/lib/src/model/internal/internal_executable_declaration.dart
+++ b/lib/src/model/internal/internal_executable_declaration.dart
@@ -42,7 +42,7 @@ class InternalExecutableDeclaration implements InternalDeclaration {
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(executableElement)!,
             parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-                executableElement.enclosingElement3),
+                executableElement.enclosingElement),
             returnTypeName: executableElement.returnType
                 .getDisplayString(withNullability: true),
             name: executableElement.displayName,

--- a/lib/src/model/internal/internal_field_declaration.dart
+++ b/lib/src/model/internal/internal_field_declaration.dart
@@ -36,7 +36,7 @@ class InternalFieldDeclaration implements InternalDeclaration {
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(fieldElement)!,
             parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-                fieldElement.enclosingElement3),
+                fieldElement.enclosingElement),
             typeName: fieldElement.type.getDisplayString(withNullability: true),
             name: fieldElement.name,
             namespace: namespace,

--- a/lib/src/model/internal/internal_interface_declaration.dart
+++ b/lib/src/model/internal/internal_interface_declaration.dart
@@ -48,7 +48,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
       : this._(
           id: InternalDeclarationUtils.getIdFromElement(interfaceElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-              interfaceElement.enclosingElement3),
+              interfaceElement.enclosingElement),
           name: interfaceElement.name,
           namespace: namespace,
           isPrivate: interfaceElement.isPrivate,
@@ -61,7 +61,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           fieldDeclarations: [],
           entryPoints: {},
           superClassIds: interfaceElement.allSupertypes
-              .map((e) => InternalDeclarationUtils.getIdFromElement(e.element2))
+              .map((e) => InternalDeclarationUtils.getIdFromElement(e.element))
               .whereNotNull()
               .toList(),
         );
@@ -72,7 +72,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
       : this._(
           id: InternalDeclarationUtils.getIdFromElement(extensionElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-              extensionElement.enclosingElement3),
+              extensionElement.enclosingElement),
           name: extensionElement.name ?? extensionElement.displayName,
           namespace: namespace,
           isPrivate: extensionElement.isPrivate,

--- a/lib/src/model/internal/internal_type_alias_declaration.dart
+++ b/lib/src/model/internal/internal_type_alias_declaration.dart
@@ -34,7 +34,7 @@ class InternalTypeAliasDeclaration implements InternalDeclaration {
       : this._(
             id: InternalDeclarationUtils.getIdFromElement(typeAliasElement)!,
             parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-                typeAliasElement.enclosingElement3),
+                typeAliasElement.enclosingElement),
             name: typeAliasElement.name,
             namespace: namespace,
             aliasedTypeName: typeAliasElement.aliasedType

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.17.5 <3.0.0"
 
 dependencies:
-  analyzer: ^5.1.0
+  analyzer: ^5.2.0
   args: ^2.3.1
   collection: ^1.16.0
   colorize: ^3.0.0


### PR DESCRIPTION
This PR changes the analyzer behavior so that elements that don't have a collected parent element get ignored (instead of adding them to root wich can cause naming collisions).

Fixes https://github.com/devmil/dart_apitool/issues/69