### PR TITLE
Abstract required interface change breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## Version 0.7.1
+## Version 0.8.0
 - improves handling of elements without root
+- changing required interfaces (even adding things) is now considered a breaking change
+  interfaces are considered 'required' if they are abstract and used in a public method or field.
+  This indicates that this interfaces is intended to be implemented by the user and therefore adding things also is breaking the API.
 
 ## Version 0.7.0
 - *BREAKING*: renamed "Class" model elements to "Interface" to reflect the abstraction it represents

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -82,6 +82,7 @@ class PackageApiAnalyzer {
     );
 
     final collectedInterfaces = <int?, _InterfaceCollectionResult>{};
+    final requiredElements = <int>{};
 
     final analyzedFiles = List<_FileToAnalyzeEntry>.empty(growable: true);
     final filesToAnalyze = Queue<_FileToAnalyzeEntry>();
@@ -216,6 +217,7 @@ class PackageApiAnalyzer {
                 );
               }
             }
+            requiredElements.addAll(collector.requiredElementIds);
           }
 
           final referencedFilesCollector = ExportedFilesCollector();
@@ -310,7 +312,8 @@ class PackageApiAnalyzer {
         assert(entry.interfaceDeclarations.length == 1,
             'We found multiple classes sharing the same classId!');
         final cd = entry.interfaceDeclarations.single;
-        packageInterfaceDeclarations.add(cd.toInterfaceDeclaration());
+        packageInterfaceDeclarations.add(cd.toInterfaceDeclaration(
+            isRequired: cd.isAbstract && requiredElements.contains(cd.id)));
       }
     }
 

--- a/lib/src/model/interface_declaration.dart
+++ b/lib/src/model/interface_declaration.dart
@@ -22,6 +22,7 @@ class InterfaceDeclaration with _$InterfaceDeclaration implements Declaration {
   const factory InterfaceDeclaration({
     required String name,
     required bool isDeprecated,
+    required bool isRequired,
     required List<String> typeParameterNames,
     required List<String> superTypeNames,
     required List<ExecutableDeclaration> executableDeclarations,

--- a/lib/src/model/interface_declaration.freezed.dart
+++ b/lib/src/model/interface_declaration.freezed.dart
@@ -18,6 +18,7 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$InterfaceDeclaration {
   String get name => throw _privateConstructorUsedError;
   bool get isDeprecated => throw _privateConstructorUsedError;
+  bool get isRequired => throw _privateConstructorUsedError;
   List<String> get typeParameterNames => throw _privateConstructorUsedError;
   List<String> get superTypeNames => throw _privateConstructorUsedError;
   List<ExecutableDeclaration> get executableDeclarations =>
@@ -40,6 +41,7 @@ abstract class $InterfaceDeclarationCopyWith<$Res> {
   $Res call(
       {String name,
       bool isDeprecated,
+      bool isRequired,
       List<String> typeParameterNames,
       List<String> superTypeNames,
       List<ExecutableDeclaration> executableDeclarations,
@@ -63,6 +65,7 @@ class _$InterfaceDeclarationCopyWithImpl<$Res,
   $Res call({
     Object? name = null,
     Object? isDeprecated = null,
+    Object? isRequired = null,
     Object? typeParameterNames = null,
     Object? superTypeNames = null,
     Object? executableDeclarations = null,
@@ -77,6 +80,10 @@ class _$InterfaceDeclarationCopyWithImpl<$Res,
       isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isRequired: null == isRequired
+          ? _value.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
       typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
@@ -113,6 +120,7 @@ abstract class _$$_InterfaceDeclarationCopyWith<$Res>
   $Res call(
       {String name,
       bool isDeprecated,
+      bool isRequired,
       List<String> typeParameterNames,
       List<String> superTypeNames,
       List<ExecutableDeclaration> executableDeclarations,
@@ -133,6 +141,7 @@ class __$$_InterfaceDeclarationCopyWithImpl<$Res>
   $Res call({
     Object? name = null,
     Object? isDeprecated = null,
+    Object? isRequired = null,
     Object? typeParameterNames = null,
     Object? superTypeNames = null,
     Object? executableDeclarations = null,
@@ -147,6 +156,10 @@ class __$$_InterfaceDeclarationCopyWithImpl<$Res>
       isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isRequired: null == isRequired
+          ? _value.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
       typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
@@ -178,6 +191,7 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
   const _$_InterfaceDeclaration(
       {required this.name,
       required this.isDeprecated,
+      required this.isRequired,
       required final List<String> typeParameterNames,
       required final List<String> superTypeNames,
       required final List<ExecutableDeclaration> executableDeclarations,
@@ -194,6 +208,8 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
   final String name;
   @override
   final bool isDeprecated;
+  @override
+  final bool isRequired;
   final List<String> _typeParameterNames;
   @override
   List<String> get typeParameterNames {
@@ -233,7 +249,7 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
 
   @override
   String toString() {
-    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
+    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, isRequired: $isRequired, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
   }
 
   @override
@@ -244,6 +260,8 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
             (identical(other.name, name) || other.name == name) &&
             (identical(other.isDeprecated, isDeprecated) ||
                 other.isDeprecated == isDeprecated) &&
+            (identical(other.isRequired, isRequired) ||
+                other.isRequired == isRequired) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -261,6 +279,7 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
       runtimeType,
       name,
       isDeprecated,
+      isRequired,
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -280,6 +299,7 @@ abstract class _InterfaceDeclaration extends InterfaceDeclaration
   const factory _InterfaceDeclaration(
       {required final String name,
       required final bool isDeprecated,
+      required final bool isRequired,
       required final List<String> typeParameterNames,
       required final List<String> superTypeNames,
       required final List<ExecutableDeclaration> executableDeclarations,
@@ -291,6 +311,8 @@ abstract class _InterfaceDeclaration extends InterfaceDeclaration
   String get name;
   @override
   bool get isDeprecated;
+  @override
+  bool get isRequired;
   @override
   List<String> get typeParameterNames;
   @override

--- a/lib/src/model/internal/internal_interface_declaration.dart
+++ b/lib/src/model/internal/internal_interface_declaration.dart
@@ -19,6 +19,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
   final String? namespace;
   final bool isPrivate;
   final bool isDeprecated;
+  final bool isAbstract;
   final List<String> typeParameterNames;
   final List<String> superTypeNames;
   final List<ExecutableDeclaration> executableDeclarations;
@@ -34,6 +35,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
     required this.namespace,
     required this.isPrivate,
     required this.isDeprecated,
+    required this.isAbstract,
     required this.typeParameterNames,
     required this.superTypeNames,
     required this.executableDeclarations,
@@ -53,6 +55,8 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           namespace: namespace,
           isPrivate: interfaceElement.isPrivate,
           isDeprecated: interfaceElement.hasDeprecated,
+          isAbstract:
+              (interfaceElement is ClassElement) && interfaceElement.isAbstract,
           typeParameterNames: InternalDeclarationUtils.computeTypeParameters(
               interfaceElement.typeParameters),
           superTypeNames: InternalDeclarationUtils.computeSuperTypeNames(
@@ -77,6 +81,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           namespace: namespace,
           isPrivate: extensionElement.isPrivate,
           isDeprecated: extensionElement.hasDeprecated,
+          isAbstract: false,
           typeParameterNames: InternalDeclarationUtils.computeTypeParameters(
               extensionElement.typeParameters),
           superTypeNames: const [],
@@ -86,7 +91,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           superClassIds: [],
         );
 
-  InterfaceDeclaration toInterfaceDeclaration() {
+  InterfaceDeclaration toInterfaceDeclaration({required bool isRequired}) {
     final namespacePrefix = namespace == null ? '' : '$namespace.';
     return InterfaceDeclaration(
       name: '$namespacePrefix$name',
@@ -96,6 +101,7 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
       executableDeclarations: executableDeclarations,
       fieldDeclarations: fieldDeclarations,
       entryPoints: entryPoints,
+      isRequired: isRequired,
     );
   }
 }

--- a/lib/src/storage/v3/interface_declaration_storage_v3.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.dart
@@ -17,6 +17,7 @@ class InterfaceDeclarationStorageV3 with _$InterfaceDeclarationStorageV3 {
   const factory InterfaceDeclarationStorageV3({
     required String name,
     required bool isDeprecated,
+    required bool isRequired,
     required List<String> typeParameterNames,
     required List<String> superTypeNames,
     required List<ExecutableDeclarationStorageV3> executableDeclarations,
@@ -31,6 +32,7 @@ class InterfaceDeclarationStorageV3 with _$InterfaceDeclarationStorageV3 {
     return InterfaceDeclaration(
       name: name,
       isDeprecated: isDeprecated,
+      isRequired: isRequired,
       typeParameterNames: typeParameterNames,
       superTypeNames: superTypeNames,
       executableDeclarations: executableDeclarations
@@ -47,6 +49,7 @@ class InterfaceDeclarationStorageV3 with _$InterfaceDeclarationStorageV3 {
     return InterfaceDeclarationStorageV3(
       name: interfaceDeclaration.name,
       isDeprecated: interfaceDeclaration.isDeprecated,
+      isRequired: interfaceDeclaration.isRequired,
       typeParameterNames: interfaceDeclaration.typeParameterNames,
       superTypeNames: interfaceDeclaration.superTypeNames,
       executableDeclarations: interfaceDeclaration.executableDeclarations

--- a/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
@@ -23,6 +23,7 @@ InterfaceDeclarationStorageV3 _$InterfaceDeclarationStorageV3FromJson(
 mixin _$InterfaceDeclarationStorageV3 {
   String get name => throw _privateConstructorUsedError;
   bool get isDeprecated => throw _privateConstructorUsedError;
+  bool get isRequired => throw _privateConstructorUsedError;
   List<String> get typeParameterNames => throw _privateConstructorUsedError;
   List<String> get superTypeNames => throw _privateConstructorUsedError;
   List<ExecutableDeclarationStorageV3> get executableDeclarations =>
@@ -48,6 +49,7 @@ abstract class $InterfaceDeclarationStorageV3CopyWith<$Res> {
   $Res call(
       {String name,
       bool isDeprecated,
+      bool isRequired,
       List<String> typeParameterNames,
       List<String> superTypeNames,
       List<ExecutableDeclarationStorageV3> executableDeclarations,
@@ -71,6 +73,7 @@ class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
   $Res call({
     Object? name = null,
     Object? isDeprecated = null,
+    Object? isRequired = null,
     Object? typeParameterNames = null,
     Object? superTypeNames = null,
     Object? executableDeclarations = null,
@@ -85,6 +88,10 @@ class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
       isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isRequired: null == isRequired
+          ? _value.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
       typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
@@ -122,6 +129,7 @@ abstract class _$$_InterfaceDeclarationStorageV3CopyWith<$Res>
   $Res call(
       {String name,
       bool isDeprecated,
+      bool isRequired,
       List<String> typeParameterNames,
       List<String> superTypeNames,
       List<ExecutableDeclarationStorageV3> executableDeclarations,
@@ -144,6 +152,7 @@ class __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>
   $Res call({
     Object? name = null,
     Object? isDeprecated = null,
+    Object? isRequired = null,
     Object? typeParameterNames = null,
     Object? superTypeNames = null,
     Object? executableDeclarations = null,
@@ -158,6 +167,10 @@ class __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>
       isDeprecated: null == isDeprecated
           ? _value.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isRequired: null == isRequired
+          ? _value.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
       typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
@@ -189,6 +202,7 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
   const _$_InterfaceDeclarationStorageV3(
       {required this.name,
       required this.isDeprecated,
+      required this.isRequired,
       required final List<String> typeParameterNames,
       required final List<String> superTypeNames,
       required final List<ExecutableDeclarationStorageV3>
@@ -210,6 +224,8 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
   final String name;
   @override
   final bool isDeprecated;
+  @override
+  final bool isRequired;
   final List<String> _typeParameterNames;
   @override
   List<String> get typeParameterNames {
@@ -247,7 +263,7 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
 
   @override
   String toString() {
-    return 'InterfaceDeclarationStorageV3(name: $name, isDeprecated: $isDeprecated, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
+    return 'InterfaceDeclarationStorageV3(name: $name, isDeprecated: $isDeprecated, isRequired: $isRequired, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints)';
   }
 
   @override
@@ -258,6 +274,8 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
             (identical(other.name, name) || other.name == name) &&
             (identical(other.isDeprecated, isDeprecated) ||
                 other.isDeprecated == isDeprecated) &&
+            (identical(other.isRequired, isRequired) ||
+                other.isRequired == isRequired) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -276,6 +294,7 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
       runtimeType,
       name,
       isDeprecated,
+      isRequired,
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -302,6 +321,7 @@ abstract class _InterfaceDeclarationStorageV3
   const factory _InterfaceDeclarationStorageV3(
           {required final String name,
           required final bool isDeprecated,
+          required final bool isRequired,
           required final List<String> typeParameterNames,
           required final List<String> superTypeNames,
           required final List<ExecutableDeclarationStorageV3>
@@ -318,6 +338,8 @@ abstract class _InterfaceDeclarationStorageV3
   String get name;
   @override
   bool get isDeprecated;
+  @override
+  bool get isRequired;
   @override
   List<String> get typeParameterNames;
   @override

--- a/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
@@ -13,6 +13,7 @@ _$_InterfaceDeclarationStorageV3 _$$_InterfaceDeclarationStorageV3FromJson(
     _$_InterfaceDeclarationStorageV3(
       name: json['name'] as String,
       isDeprecated: json['isDeprecated'] as bool,
+      isRequired: json['isRequired'] as bool,
       typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
@@ -37,6 +38,7 @@ Map<String, dynamic> _$$_InterfaceDeclarationStorageV3ToJson(
     <String, dynamic>{
       'name': instance.name,
       'isDeprecated': instance.isDeprecated,
+      'isRequired': instance.isRequired,
       'typeParameterNames': instance.typeParameterNames,
       'superTypeNames': instance.superTypeNames,
       'executableDeclarations': instance.executableDeclarations,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A tool to analyze the public API of a package, create a model of it
 homepage: https://devmil.de
 repository: https://github.com/devmil/dart_apitool
 
-version: 0.7.1-dev
+version: 0.8.0-dev
 
 environment:
   sdk: ">=2.17.5 <3.0.0"

--- a/test/integration_tests/diff/sqflite_common_test.dart
+++ b/test/integration_tests/diff/sqflite_common_test.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: non_constant_identifier_names
+
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+
+import '../helper/integration_test_helper.dart';
+
+void main() {
+  group('sqflite_common diff', () {
+    group('2.3.0 to 2.4.0', () {
+      final packageName = 'sqflite_common';
+      final sqflite_common_2_3_0 = PackageApiRetriever(packageName, '2.3.0');
+      final sqflite_common_2_4_0 = PackageApiRetriever(packageName, '2.4.0');
+      late PackageApiDiffResult diffResult;
+
+      setUpAll(() async {
+        diffResult = PackageApiDiffer().diff(
+            oldApi: await sqflite_common_2_3_0.retrieve(),
+            newApi: await sqflite_common_2_4_0.retrieve());
+      });
+
+      test('detects required interface change as breaking', () {
+        final isBreakingChange =
+            diffResult.apiChanges.any((element) => element.type.isBreaking);
+        expect(isBreakingChange, isTrue);
+      });
+    });
+  });
+}

--- a/test/integration_tests/diff/sqflite_common_test.dart
+++ b/test/integration_tests/diff/sqflite_common_test.dart
@@ -19,9 +19,11 @@ void main() {
             newApi: await sqflite_common_2_4_0.retrieve());
       });
 
-      test('detects required interface change as breaking', () {
-        final isBreakingChange =
-            diffResult.apiChanges.any((element) => element.type.isBreaking);
+      test('detects rawQueryCursor added to required interface as breaking',
+          () {
+        final isBreakingChange = diffResult.apiChanges.any((element) =>
+            element.affectedDeclaration!.name == 'rawQueryCursor' &&
+            element.type.isBreaking);
         expect(isBreakingChange, isTrue);
       });
     });

--- a/test/package_api_differ_test_data.dart
+++ b/test/package_api_differ_test_data.dart
@@ -17,6 +17,7 @@ final simpleClassA = InterfaceDeclaration(
     ),
   ],
   fieldDeclarations: const [],
+  isRequired: false,
 );
 final simpleClassB = InterfaceDeclaration(
   name: 'ClassB',
@@ -35,6 +36,7 @@ final simpleClassB = InterfaceDeclaration(
     ),
   ],
   fieldDeclarations: const [],
+  isRequired: false,
 );
 
 final packageClassAApi = PackageApi(

--- a/test/package_api_storage_test.dart
+++ b/test/package_api_storage_test.dart
@@ -120,6 +120,7 @@ final testPackage1Api = PackageApi(
           isStatic: false,
         ),
       ],
+      isRequired: false,
     )
   ],
   executableDeclarations: const [],
@@ -237,7 +238,8 @@ final testPackage2Api = PackageApi(
         ),
       ],
       entryPoints: {},
-    )
+      isRequired: false,
+    ),
   ],
   executableDeclarations: const [],
   fieldDeclarations: const [],


### PR DESCRIPTION
This PR adds the detection of required interfaces.
Required interfaces are interfaces (abstract classes) that might be intended to be implemented by the user of the API.
If those interfaces are changed (even if only stuff got added) then this changes is breaking.

The Analyzer part of dart_apitool considers interfaces required if they are abstract and used as an executable parameter or writable field.

Fixes https://github.com/devmil/dart_apitool/issues/70