### PR TITLE
Relative path usage cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.9.1
+- use the relative path only for top level entities
+- use a more stable way of getting the relative path
+
 ## Version 0.9.0
 - Adds detection and consideration of @experimental flag
 - Increases robustness regarding

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -33,10 +33,14 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
 
     /// [collectedElementIds] is the set of element ids that are already collected and therefore should not be collected (again) by this visitor
     Set<int>? collectedElementIds,
+
+    /// the root path of the project
+    required String rootPath,
   }) : _context = _AnalysisContext(
           shownNames: shownNames,
           hiddenNames: hiddenNames,
           namespace: namespace,
+          rootPath: rootPath,
         ) {
     _collectedElementIds = <int>{};
     if (collectedElementIds != null) {
@@ -119,6 +123,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
         collectedElementIds: _collectedElementIds,
         namespace:
             _getNamespaceForLibrary(directElementLibrary, referringElement),
+        rootPath: _context.rootPath,
       );
       directElement.accept(collector);
       // merge result with this result
@@ -185,9 +190,12 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     if (!_markElementAsCollected(interfaceElement)) {
       return false;
     }
-    _interfaceDeclarations.add(
-        InternalInterfaceDeclaration.fromInterfaceElement(interfaceElement,
-            namespace: _context.namespace));
+    _interfaceDeclarations
+        .add(InternalInterfaceDeclaration.fromInterfaceElement(
+      interfaceElement,
+      namespace: _context.namespace,
+      rootPath: _context.rootPath,
+    ));
     for (final st in interfaceElement.allSupertypes) {
       if (!st.isDartCoreObject && !st.isDartCoreEnum) {
         _onTypeUsed(st, interfaceElement, isRequired: false);
@@ -226,8 +234,10 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     if (!_markElementAsCollected(element)) {
       return;
     }
-    _fieldDeclarations
-        .add(InternalFieldDeclaration.fromPropertyInducingElement(element));
+    _fieldDeclarations.add(InternalFieldDeclaration.fromPropertyInducingElement(
+      element,
+      rootPath: _context.rootPath,
+    ));
     super.visitFieldElement(element);
     if (element.type.element2 != null) {
       bool canBeSet =
@@ -248,6 +258,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     _fieldDeclarations.add(InternalFieldDeclaration.fromPropertyInducingElement(
       element,
       namespace: _context.namespace,
+      rootPath: _context.rootPath,
     ));
     super.visitTopLevelVariableElement(element);
     if (element.type.element2 != null) {
@@ -279,6 +290,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     _executableDeclarations
         .add(InternalExecutableDeclaration.fromExecutableElement(
       element,
+      rootPath: _context.rootPath,
     ));
     super.visitMethodElement(element);
     if (element.returnType.element2 != null) {
@@ -299,6 +311,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
         .add(InternalExecutableDeclaration.fromExecutableElement(
       element,
       namespace: _context.namespace,
+      rootPath: _context.rootPath,
     ));
     super.visitFunctionElement(element);
     if (element.returnType.element2 != null) {
@@ -317,7 +330,10 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     }
 
     _executableDeclarations
-        .add(InternalExecutableDeclaration.fromExecutableElement(element));
+        .add(InternalExecutableDeclaration.fromExecutableElement(
+      element,
+      rootPath: _context.rootPath,
+    ));
 
     super.visitConstructorElement(element);
   }
@@ -335,6 +351,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
         .add(InternalTypeAliasDeclaration.fromTypeAliasElement(
       element,
       namespace: _context.namespace,
+      rootPath: _context.rootPath,
     ));
     super.visitTypeAliasElement(element);
     if (element.aliasedType.element2 != null) {
@@ -363,9 +380,12 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     if (!_markElementAsCollected(element)) {
       return;
     }
-    _interfaceDeclarations.add(
-        InternalInterfaceDeclaration.fromExtensionElement(element,
-            namespace: _context.namespace));
+    _interfaceDeclarations
+        .add(InternalInterfaceDeclaration.fromExtensionElement(
+      element,
+      namespace: _context.namespace,
+      rootPath: _context.rootPath,
+    ));
     if (element.extendedType.element2 != null) {
       _onTypeUsed(element.extendedType, element, isRequired: false);
     }
@@ -378,10 +398,12 @@ class _AnalysisContext {
   final List<String> shownNames;
   final List<String> hiddenNames;
   final String? namespace;
+  final String rootPath;
 
   _AnalysisContext({
     this.shownNames = const [],
     this.hiddenNames = const [],
     this.namespace,
+    required this.rootPath,
   });
 }

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -110,6 +110,7 @@ class PackageApiAnalyzer {
             final collector = APIRelevantElementsCollector(
               shownNames: fileToAnalyze.shownNames,
               hiddenNames: fileToAnalyze.hiddenNames,
+              rootPath: normalizedAbsoluteProjectPath,
             );
             unitResult.libraryElement.accept(collector);
             final skippedInterfaces = <int>[];

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -102,9 +102,10 @@ class PackageApiDiffer {
       oldInterfaces,
       newInterfaces,
       (oldInterface, newInterface) =>
-          // for interfaces we have to consider the path as well as we might run into duplicate namings otherwise
+          // for top level elements we have to consider the path as well as we might run into duplicate namings otherwise
           oldInterface.name == newInterface.name &&
-          oldInterface.relativePath == newInterface.relativePath,
+          (context.isNotEmpty ||
+              oldInterface.relativePath == newInterface.relativePath),
     );
     final changes = <ApiChange>[];
     for (final oldInterface in interfaceListDiff.matches.keys) {
@@ -219,9 +220,13 @@ class PackageApiDiffer {
     required bool isExperimental,
   }) {
     final executableListDiff = _diffIterables<ExecutableDeclaration>(
-        oldExecutables,
-        newExecutables,
-        (oldEx, newEx) => oldEx.name == newEx.name);
+      oldExecutables,
+      newExecutables,
+      (oldEx, newEx) =>
+          // for top level elements we have to consider the path as well as we might run into duplicate namings otherwise
+          oldEx.name == newEx.name &&
+          (context.isNotEmpty || oldEx.relativePath == newEx.relativePath),
+    );
     final changes = <ApiChange>[];
     for (final oldEx in executableListDiff.matches.keys) {
       final newEx = executableListDiff.matches[oldEx]!;
@@ -713,9 +718,14 @@ class PackageApiDiffer {
     required isExperimental,
   }) {
     final fieldsDiff = _diffIterables<FieldDeclaration>(
-        oldFieldDeclarations,
-        newFieldDeclarations,
-        (oldField, newField) => oldField.name == newField.name);
+      oldFieldDeclarations,
+      newFieldDeclarations,
+      (oldField, newField) =>
+          // for top level elements we have to consider the path as well as we might run into duplicate namings otherwise
+          oldField.name == newField.name &&
+          (context.isNotEmpty ||
+              oldField.relativePath == newField.relativePath),
+    );
     final changes = <ApiChange>[];
     for (final oldField in fieldsDiff.matches.keys) {
       final newField = fieldsDiff.matches[oldField]!;

--- a/lib/src/model/internal/internal_declaration_utils.dart
+++ b/lib/src/model/internal/internal_declaration_utils.dart
@@ -40,16 +40,10 @@ abstract class InternalDeclarationUtils {
     return result;
   }
 
-  static String getRelativePath(Element element) {
+  static String getRelativePath(String rootPath, Element element) {
     final name = element.librarySource?.fullName;
     if (name != null) {
-      final parts = path.split(name);
-      int libIndex = parts.indexWhere((element) => element == 'lib');
-      if (libIndex > 0) {
-        final rootPath = path.joinAll(parts.take(libIndex));
-        return path.relative(name, from: rootPath);
-      }
-      return name;
+      return path.relative(name, from: rootPath);
     }
     return '';
   }

--- a/lib/src/model/internal/internal_executable_declaration.dart
+++ b/lib/src/model/internal/internal_executable_declaration.dart
@@ -42,9 +42,10 @@ class InternalExecutableDeclaration implements InternalDeclaration {
   });
 
   InternalExecutableDeclaration.fromExecutableElement(
-      ExecutableElement executableElement,
-      {String? namespace})
-      : this._(
+    ExecutableElement executableElement, {
+    String? namespace,
+    required String rootPath,
+  }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(executableElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
               executableElement.enclosingElement),
@@ -55,15 +56,17 @@ class InternalExecutableDeclaration implements InternalDeclaration {
           isDeprecated: executableElement.hasDeprecated,
           isExperimental:
               InternalDeclarationUtils.hasExperimental(executableElement),
-          parameters: _computeParameterList(executableElement.parameters,
-              InternalDeclarationUtils.getRelativePath(executableElement)),
+          parameters: _computeParameterList(
+              executableElement.parameters,
+              InternalDeclarationUtils.getRelativePath(
+                  rootPath, executableElement)),
           typeParameterNames:
               _computeTypeParameters(executableElement.typeParameters),
           type: _computeExecutableType(executableElement),
           isStatic: executableElement.isStatic,
           entryPoints: {},
-          relativePath:
-              InternalDeclarationUtils.getRelativePath(executableElement),
+          relativePath: InternalDeclarationUtils.getRelativePath(
+              rootPath, executableElement),
         );
 
   ExecutableDeclaration toExecutableDeclaration() {

--- a/lib/src/model/internal/internal_field_declaration.dart
+++ b/lib/src/model/internal/internal_field_declaration.dart
@@ -36,9 +36,10 @@ class InternalFieldDeclaration implements InternalDeclaration {
   });
 
   InternalFieldDeclaration.fromPropertyInducingElement(
-      PropertyInducingElement fieldElement,
-      {String? namespace})
-      : this._(
+    PropertyInducingElement fieldElement, {
+    String? namespace,
+    required String rootPath,
+  }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(fieldElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
               fieldElement.enclosingElement),
@@ -50,7 +51,8 @@ class InternalFieldDeclaration implements InternalDeclaration {
               InternalDeclarationUtils.hasExperimental(fieldElement),
           isStatic: fieldElement.isStatic,
           entryPoints: {},
-          relativePath: InternalDeclarationUtils.getRelativePath(fieldElement),
+          relativePath:
+              InternalDeclarationUtils.getRelativePath(rootPath, fieldElement),
         );
 
   FieldDeclaration toFieldDeclaration() {

--- a/lib/src/model/internal/internal_interface_declaration.dart
+++ b/lib/src/model/internal/internal_interface_declaration.dart
@@ -50,9 +50,10 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
   });
 
   InternalInterfaceDeclaration.fromInterfaceElement(
-      InterfaceElement interfaceElement,
-      {String? namespace})
-      : this._(
+    InterfaceElement interfaceElement, {
+    String? namespace,
+    required String rootPath,
+  }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(interfaceElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
               interfaceElement.enclosingElement),
@@ -71,8 +72,8 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           executableDeclarations: [],
           fieldDeclarations: [],
           entryPoints: {},
-          relativePath:
-              InternalDeclarationUtils.getRelativePath(interfaceElement),
+          relativePath: InternalDeclarationUtils.getRelativePath(
+              rootPath, interfaceElement),
           superClassIds: interfaceElement.allSupertypes
               .map((e) => InternalDeclarationUtils.getIdFromElement(e.element))
               .whereNotNull()
@@ -80,9 +81,10 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
         );
 
   InternalInterfaceDeclaration.fromExtensionElement(
-      ExtensionElement extensionElement,
-      {String? namespace})
-      : this._(
+    ExtensionElement extensionElement, {
+    String? namespace,
+    required String rootPath,
+  }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(extensionElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
               extensionElement.enclosingElement),
@@ -99,8 +101,8 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           executableDeclarations: [],
           fieldDeclarations: [],
           entryPoints: {},
-          relativePath:
-              InternalDeclarationUtils.getRelativePath(extensionElement),
+          relativePath: InternalDeclarationUtils.getRelativePath(
+              rootPath, extensionElement),
           superClassIds: [],
         );
 

--- a/lib/src/model/internal/internal_type_alias_declaration.dart
+++ b/lib/src/model/internal/internal_type_alias_declaration.dart
@@ -34,9 +34,10 @@ class InternalTypeAliasDeclaration implements InternalDeclaration {
   });
 
   InternalTypeAliasDeclaration.fromTypeAliasElement(
-      TypeAliasElement typeAliasElement,
-      {String? namespace})
-      : this._(
+    TypeAliasElement typeAliasElement, {
+    String? namespace,
+    required String rootPath,
+  }) : this._(
             id: InternalDeclarationUtils.getIdFromElement(typeAliasElement)!,
             parentClassId: InternalDeclarationUtils.getIdFromParentElement(
                 typeAliasElement.enclosingElement),
@@ -48,8 +49,8 @@ class InternalTypeAliasDeclaration implements InternalDeclaration {
             isExperimental:
                 InternalDeclarationUtils.hasExperimental(typeAliasElement),
             entryPoints: {},
-            relativePath:
-                InternalDeclarationUtils.getRelativePath(typeAliasElement));
+            relativePath: InternalDeclarationUtils.getRelativePath(
+                rootPath, typeAliasElement));
 
   TypeAliasDeclaration toTypeAliasDeclaration() {
     final namespacePrefix = namespace == null ? '' : '$namespace.';

--- a/test/test_packages/experimental_diff/package_a_with_experimental/lib/duplicates/class_a.dart
+++ b/test/test_packages/experimental_diff/package_a_with_experimental/lib/duplicates/class_a.dart
@@ -1,0 +1,5 @@
+class ClassA {
+  final int age;
+
+  ClassA(this.age);
+}

--- a/test/test_packages/experimental_diff/package_a_with_experimental/lib/package_a_duplicates.dart
+++ b/test/test_packages/experimental_diff/package_a_with_experimental/lib/package_a_duplicates.dart
@@ -1,0 +1,3 @@
+library package_a;
+
+export 'duplicates/class_a.dart';

--- a/test/test_packages/experimental_diff/package_a_with_experimental/pubspec.yaml
+++ b/test/test_packages/experimental_diff/package_a_with_experimental/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.18.4 <3.0.0'
 
 dependencies:
+  collection: ^1.17.0
   meta: ^1.8.0
 
 dev_dependencies:

--- a/test/test_packages/experimental_diff/package_a_without_experimental/lib/duplicates/class_a.dart
+++ b/test/test_packages/experimental_diff/package_a_without_experimental/lib/duplicates/class_a.dart
@@ -1,0 +1,5 @@
+class ClassA {
+  final int age;
+
+  ClassA(this.age);
+}

--- a/test/test_packages/experimental_diff/package_a_without_experimental/lib/package_a_duplicates.dart
+++ b/test/test_packages/experimental_diff/package_a_without_experimental/lib/package_a_duplicates.dart
@@ -1,0 +1,3 @@
+library package_a;
+
+export 'duplicates/class_a.dart';

--- a/test/test_packages/experimental_diff/package_a_without_experimental/pubspec.yaml
+++ b/test/test_packages/experimental_diff/package_a_without_experimental/pubspec.yaml
@@ -6,6 +6,9 @@ version: 1.0.0
 environment:
   sdk: '>=2.18.4 <3.0.0'
 
+dependencies:
+  meta: ^1.8.0
+
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0


### PR DESCRIPTION
- relative path comparison is now used for all types (interface, executable, field) but only on top-level
- the relative path is now calculated based on the root path that is passed in instead of some wild name-guessing on the file path