### PR TITLE
Fix version check on no changes and introduce version check mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## Version 0.10.1
+## Version 0.11.0
+- replaces `--check-versions` with `--version-check-mode`
 
 ## Version 0.10.0
 - adds include-path-dependencies parameters

--- a/lib/src/diff/diff.dart
+++ b/lib/src/diff/diff.dart
@@ -5,3 +5,4 @@ export 'dependency_check_mode.dart';
 export 'package_api_diff_result.dart';
 export 'package_api_differ_options.dart';
 export 'package_api_differ.dart';
+export 'version_check_mode.dart';

--- a/lib/src/diff/version_check_mode.dart
+++ b/lib/src/diff/version_check_mode.dart
@@ -1,0 +1,11 @@
+/// version check mode to apply
+enum VersionCheckMode {
+  /// no version check
+  none,
+
+  /// complete version check (breaking and non-breaking changes)
+  fully,
+
+  /// only breaking changes
+  onlyBreakingChanges,
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A tool to analyze the public API of a package, create a model of it
 homepage: https://devmil.de
 repository: https://github.com/devmil/dart_apitool
 
-version: 0.10.1-dev
+version: 0.11.0-dev
 
 environment:
   sdk: ">=2.17.5 <3.0.0"

--- a/test/integration_tests/cli/diff_command_test.dart
+++ b/test/integration_tests/cli/diff_command_test.dart
@@ -1,0 +1,31 @@
+import 'package:args/command_runner.dart';
+import 'package:dart_apitool/api_tool_cli.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('diff', () {
+    test('diffing the same package works', () async {
+      final diffCommand = DiffCommand();
+      final packagePath = path.join(
+        'test',
+        'test_packages',
+        'path_references',
+        'cluster_a',
+        'package_a',
+      );
+      final runner =
+          CommandRunner<int>('dart_apitool_tests', 'Test for dart_apitool')
+            ..addCommand(diffCommand);
+      final exitCode = await runner.run([
+        'diff',
+        '--old',
+        packagePath,
+        '--new',
+        packagePath,
+        '--include-path-dependencies',
+      ]);
+      expect(exitCode, 0);
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes the version check behavior if there are no changes (#92).
It also introduces a more fine granular selection of what part of the version to check (#91)