### PR TITLE
Bugfix: handle nested projects with path dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.11.0
 - replaces `--check-versions` with `--version-check-mode`
+- reduces the amount of directories to copy in a path-dependency-context
 
 ## Version 0.10.1 
 - fixes an issue with projects having path dependencies to projects inside their folder structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Version 0.11.0
 - replaces `--check-versions` with `--version-check-mode`
 
+## Version 0.10.1 
+- fixes an issue with projects having path dependencies to projects inside their folder structure
+
 ## Version 0.10.0
 - adds include-path-dependencies parameters
 - dependencies are ignored if one side of the diff is a path dependency

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -74,6 +74,10 @@ Affects only local references.
     } else {
       throw ArgumentError('Unknown package ref: ${ref.ref}');
     }
+    // merge sources to not copy children of a parent separately
+    // => remove all sources that have a parent in the list
+    sources.removeWhere((sToRemove) => sources.any(
+        (s) => s != sToRemove && p.isWithin(s.sourceDir, sToRemove.sourceDir)));
     final tempDir = await Directory.systemTemp.createTemp();
     await Future.forEach<SourceItem>(sources, (sourceItem) async {
       stdout.writeln('Copying sources from ${sourceItem.sourceDir}');

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -77,7 +77,7 @@ Affects only local references.
     // merge sources to not copy children of a parent separately
     // => remove all sources that have a parent in the list
     sources.removeWhere((sToRemove) => sources.any(
-        (s) => s != sToRemove && p.isWithin(s.sourceDir, sToRemove.sourceDir)));
+        (s) => p.isWithin(s.sourceDir, sToRemove.sourceDir)));
     final tempDir = await Directory.systemTemp.createTemp();
     await Future.forEach<SourceItem>(sources, (sourceItem) async {
       stdout.writeln('Copying sources from ${sourceItem.sourceDir}');

--- a/test/integration_tests/cli/diff_command_test.dart
+++ b/test/integration_tests/cli/diff_command_test.dart
@@ -27,5 +27,5 @@ void main() {
       ]);
       expect(exitCode, 0);
     });
-  });
+  }, timeout: Timeout(Duration(minutes: 2)));
 }

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -12,7 +12,7 @@ void main() {
             ..addCommand(extractCommand);
       // executes "extract" command for a set of packages that is linked via path dependencies
       // using "expect()" here results in an early return due to FakeAsync not being able to handle this
-      await runner.run([
+      final exitCode = await runner.run([
         'extract',
         '--input',
         path.join(
@@ -24,6 +24,7 @@ void main() {
         ),
         '--include-path-dependencies',
       ]);
+      expect(exitCode, 0);
     });
     test(
         'Fails with path dependencies pointing outside without include-path-dependencies argument',
@@ -82,5 +83,26 @@ void main() {
         'pub://dart_apitool/0.4.0',
       ]);
     });
-  });
+
+    test('Can handle nested path dependencies', () async {
+      final extractCommand = ExtractCommand();
+      final runner =
+          CommandRunner<int>('dart_apitool_tests', 'Test for dart_apitool')
+            ..addCommand(extractCommand);
+      // executes "extract" command for a set of packages that is linked via path dependencies
+      // using "expect()" here results in an early return due to FakeAsync not being able to handle this
+      final exitCode = await runner.run([
+        'extract',
+        '--input',
+        path.join(
+          'test',
+          'test_packages',
+          'nested_path_references',
+          'package_a',
+        ),
+        '--include-path-dependencies',
+      ]);
+      expect(exitCode, 0);
+    });
+  }, timeout: Timeout(Duration(minutes: 2)));
 }

--- a/test/test_packages/nested_path_references/package_a/.gitignore
+++ b/test/test_packages/nested_path_references/package_a/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/nested_path_references/package_a/CHANGELOG.md
+++ b/test/test_packages/nested_path_references/package_a/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/nested_path_references/package_a/README.md
+++ b/test/test_packages/nested_path_references/package_a/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/nested_path_references/package_a/analysis_options.yaml
+++ b/test/test_packages/nested_path_references/package_a/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/nested_path_references/package_a/lib/package_a.dart
+++ b/test/test_packages/nested_path_references/package_a/lib/package_a.dart
@@ -1,0 +1,3 @@
+library package_a;
+
+export 'types/class_a.dart';

--- a/test/test_packages/nested_path_references/package_a/lib/types/class_a.dart
+++ b/test/test_packages/nested_path_references/package_a/lib/types/class_a.dart
@@ -1,0 +1,13 @@
+import 'package:meta/meta.dart';
+import 'package:package_b/package_b.dart';
+
+@experimental
+class ClassA {
+  final ClassB classB;
+
+  ClassA({required this.classB});
+
+  String getName() {
+    return classB.getName();
+  }
+}

--- a/test/test_packages/nested_path_references/package_a/package_b/.gitignore
+++ b/test/test_packages/nested_path_references/package_a/package_b/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/nested_path_references/package_a/package_b/CHANGELOG.md
+++ b/test/test_packages/nested_path_references/package_a/package_b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/nested_path_references/package_a/package_b/README.md
+++ b/test/test_packages/nested_path_references/package_a/package_b/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/nested_path_references/package_a/package_b/analysis_options.yaml
+++ b/test/test_packages/nested_path_references/package_a/package_b/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/nested_path_references/package_a/package_b/lib/package_b.dart
+++ b/test/test_packages/nested_path_references/package_a/package_b/lib/package_b.dart
@@ -1,0 +1,3 @@
+library package_b;
+
+export 'types/class_b.dart';

--- a/test/test_packages/nested_path_references/package_a/package_b/lib/types/class_b.dart
+++ b/test/test_packages/nested_path_references/package_a/package_b/lib/types/class_b.dart
@@ -1,0 +1,13 @@
+import 'package:meta/meta.dart';
+import 'package:package_c/package_c.dart';
+
+@experimental
+class ClassB {
+  final ClassC classC;
+
+  ClassB({required this.classC});
+
+  String getName() {
+    return classC.getName();
+  }
+}

--- a/test/test_packages/nested_path_references/package_a/package_b/package_c/.gitignore
+++ b/test/test_packages/nested_path_references/package_a/package_b/package_c/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/nested_path_references/package_a/package_b/package_c/CHANGELOG.md
+++ b/test/test_packages/nested_path_references/package_a/package_b/package_c/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/nested_path_references/package_a/package_b/package_c/README.md
+++ b/test/test_packages/nested_path_references/package_a/package_b/package_c/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/nested_path_references/package_a/package_b/package_c/analysis_options.yaml
+++ b/test/test_packages/nested_path_references/package_a/package_b/package_c/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/nested_path_references/package_a/package_b/package_c/lib/package_c.dart
+++ b/test/test_packages/nested_path_references/package_a/package_b/package_c/lib/package_c.dart
@@ -1,0 +1,3 @@
+library package_c;
+
+export 'types/class_c.dart';

--- a/test/test_packages/nested_path_references/package_a/package_b/package_c/lib/types/class_c.dart
+++ b/test/test_packages/nested_path_references/package_a/package_b/package_c/lib/types/class_c.dart
@@ -1,0 +1,12 @@
+import 'package:meta/meta.dart';
+
+@experimental
+class ClassC {
+  final String name;
+
+  ClassC({required this.name});
+
+  String getName() {
+    return name;
+  }
+}

--- a/test/test_packages/nested_path_references/package_a/package_b/package_c/pubspec.yaml
+++ b/test/test_packages/nested_path_references/package_a/package_b/package_c/pubspec.yaml
@@ -1,0 +1,16 @@
+name: package_c
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+publish_to: none
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+dependencies:
+  collection: ^1.17.0
+  meta: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/test/test_packages/nested_path_references/package_a/package_b/pubspec.yaml
+++ b/test/test_packages/nested_path_references/package_a/package_b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: package_b
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+publish_to: none
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+dependencies:
+  collection: ^1.17.0
+  meta: ^1.8.0
+  package_c:
+    path: package_c
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0

--- a/test/test_packages/nested_path_references/package_a/pubspec.yaml
+++ b/test/test_packages/nested_path_references/package_a/pubspec.yaml
@@ -1,0 +1,18 @@
+name: package_a
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+publish_to: none
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+dependencies:
+  collection: ^1.17.0
+  meta: ^1.8.0
+  package_b:
+    path: package_b
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0


### PR DESCRIPTION
This PR introduces a fix for an issue with nested path dependencies.
It filters all paths that already have a parent path in the list from the list of directories to copy.

Also introduces bigger timeouts for the CLI integration tests (solves #95)