### PR TITLE
Prepare Flutter upgrade

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.3.10",
+  "flutterSdkVersion": "3.7.0",
   "flavors": {}
 }

--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.7.0",
+  "flutterSdkVersion": "3.3.10",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.11.0
 - replaces `--check-versions` with `--version-check-mode`
 - reduces the amount of directories to copy in a path-dependency-context
+- fixes an issue with cache location and Flutter 3.7.0
 
 ## Version 0.10.1 
 - fixes an issue with projects having path dependencies to projects inside their folder structure


### PR DESCRIPTION
Flutter 3.7.0 seems to introduce a new cache location behavior (at certain circumstances) that leads to dart-apitool not finding the downloaded packages.
This PR prepares dart-apitool for this