### PR TITLE
fix local package refs

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.7.0",
+  "flutterSdkVersion": "3.7.3",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.11.1
+- fixes parsing of local package references
+
 ## Version 0.11.0
 - replaces `--check-versions` with `--version-check-mode`
 - reduces the amount of directories to copy in a path-dependency-context

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -409,7 +409,7 @@ class PackageApiAnalyzer {
       throw ArgumentError.value(libraryIdentifier, 'libraryIdentifier',
           'Looks like a package (starts with \'package:\' but doesn\'t contain \'/\'');
     }
-    return libraryIdentifier.substring(libraryIdentifier.indexOf('/'));
+    return libraryIdentifier.substring(libraryIdentifier.indexOf('/') + 1);
   }
 
   bool _isInternalRef(


### PR DESCRIPTION
This PR fixes local package references (they became absolute instead of relative)

also: increase Flutter version to 3.7.3

fixes #106