### PR TITLE
improve dependency diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.12.0
+- extend handling of change types to include "breaking", "non-breaking-minor" and "non-breaking-patch" changes
+
 ## Version 0.11.1
 - fixes parsing of local package references
 

--- a/lib/src/diff/api_change_type.dart
+++ b/lib/src/diff/api_change_type.dart
@@ -1,24 +1,38 @@
 /// represents the type of API change
 enum ApiChangeType {
   /// breaking change
-  changeBreaking(isBreaking: true),
+  changeBreaking(isBreaking: true, requiresMinorBump: true),
 
-  /// non-breaking change
-  changeCompatible(isBreaking: false),
+  /// non-breaking change that requires a minor bump
+  changeCompatibleMinor(isBreaking: false, requiresMinorBump: true),
+
+  /// non-breaking change that only requires a patch bump
+  changeCompatiblePatch(isBreaking: false, requiresMinorBump: false),
 
   /// removal (breaking)
-  remove(isBreaking: true),
+  remove(isBreaking: true, requiresMinorBump: true),
 
   /// removal (non-breaking, rather rare)
-  removeCompatible(isBreaking: false),
+  removeCompatibleMinor(isBreaking: false, requiresMinorBump: true),
 
-  /// non-breaking addition
-  addCompatible(isBreaking: false),
+  /// removal (non-breaking, probably never used)
+  removeCompatiblePatch(isBreaking: false, requiresMinorBump: false),
+
+  /// non-breaking addition that requires a minor bump
+  addCompatibleMinor(isBreaking: false, requiresMinorBump: true),
+
+  /// non-breaking addition that only requires a patch bump
+  addCompatiblePatch(isBreaking: false, requiresMinorBump: false),
 
   /// breaking addition (like adding a required parameter)
-  addBreaking(isBreaking: true);
+  addBreaking(isBreaking: true, requiresMinorBump: true);
 
+  /// determines if the change is breaking
   final bool isBreaking;
 
-  const ApiChangeType({required this.isBreaking});
+  /// determines if the change requires a minor bump (if false then it requires a patch bump)
+  final bool requiresMinorBump;
+
+  const ApiChangeType(
+      {required this.isBreaking, required this.requiresMinorBump});
 }

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -133,7 +133,7 @@ class PackageApiDiffer {
         changeCode: ApiChangeCode.ci02,
         affectedDeclaration: addedInterface,
         contextTrace: _contextTraceFromStack(context),
-        type: ApiChangeType.addCompatible,
+        type: ApiChangeType.addCompatibleMinor,
         isExperimental: isExperimental,
         changeDescription: 'Interface "${addedInterface.name}" added',
       ));
@@ -257,7 +257,7 @@ class PackageApiDiffer {
         contextTrace: _contextTraceFromStack(context),
         type: isInterfaceRequired ?? false
             ? ApiChangeType.addBreaking
-            : ApiChangeType.addCompatible,
+            : ApiChangeType.addCompatibleMinor,
         isExperimental: isExperimental,
         changeDescription:
             '${_getExecutableTypeName(addedExecutable.type, context.isNotEmpty)} "${addedExecutable.name}" added${(isInterfaceRequired ?? false) ? ' (required)' : ''}',
@@ -488,7 +488,7 @@ class PackageApiDiffer {
         contextTrace: _contextTraceFromStack(context),
         type: (isInterfaceRequired ?? false) || addedParameter.isRequired
             ? ApiChangeType.addBreaking
-            : ApiChangeType.addCompatible,
+            : ApiChangeType.addCompatibleMinor,
         isExperimental: isExperimental,
         changeDescription:
             'Parameter "${addedParameter.name}" added${(isInterfaceRequired ?? false) ? ' (required)' : ''}',
@@ -610,7 +610,7 @@ class PackageApiDiffer {
         contextTrace: _contextTraceFromStack(context),
         affectedDeclaration: context.top(),
         changeDescription: 'New entry point: $newEntryPoint',
-        type: ApiChangeType.addCompatible,
+        type: ApiChangeType.addCompatibleMinor,
         isExperimental: isExperimental,
       ));
     }
@@ -704,7 +704,7 @@ class PackageApiDiffer {
           changeCode: ApiChangeCode.ci04,
           affectedDeclaration: context.top(),
           contextTrace: _contextTraceFromStack(context),
-          type: ApiChangeType.addCompatible,
+          type: ApiChangeType.addCompatibleMinor,
           isExperimental: isExperimental,
           changeDescription: 'Super Type "$addedSuperType" added'));
     }
@@ -755,7 +755,7 @@ class PackageApiDiffer {
           contextTrace: _contextTraceFromStack(context),
           type: (isInterfaceRequired ?? false)
               ? ApiChangeType.addBreaking
-              : ApiChangeType.addCompatible,
+              : ApiChangeType.addCompatibleMinor,
           isExperimental: isExperimental,
           changeDescription:
               'Field "${addedField.name}" added${(isInterfaceRequired ?? false) ? ' (required)' : ''}'));
@@ -873,7 +873,7 @@ class PackageApiDiffer {
           contextTrace: [],
           type: isBreaking
               ? ApiChangeType.changeBreaking
-              : ApiChangeType.changeCompatible,
+              : ApiChangeType.changeCompatibleMinor,
           isExperimental: isExperimental,
           changeDescription:
               'iOS platform minimum version changed from ${oldConstraints.minimumOsVersion} to ${newConstraints.minimumOsVersion}',
@@ -961,7 +961,7 @@ class PackageApiDiffer {
         contextTrace: [],
         type: isBreaking
             ? ApiChangeType.changeBreaking
-            : ApiChangeType.changeCompatible,
+            : ApiChangeType.changeCompatibleMinor,
         isExperimental: isExperimental,
         changeDescription:
             'Android platform $valName changed from $oldVal to $newVal',
@@ -1062,7 +1062,7 @@ class PackageApiDiffer {
             affectedDeclaration: null,
             contextTrace: [],
             type: options.dependencyCheckMode == DependencyCheckMode.allowAdding
-                ? ApiChangeType.addCompatible
+                ? ApiChangeType.addCompatibleMinor
                 : ApiChangeType.addBreaking,
             isExperimental: isExperimental,
             changeDescription: 'Package dependency added: "$dependencyName"',
@@ -1078,7 +1078,7 @@ class PackageApiDiffer {
             changeCode: ApiChangeCode.cd02,
             affectedDeclaration: null,
             contextTrace: [],
-            type: ApiChangeType.removeCompatible,
+            type: ApiChangeType.changeCompatiblePatch,
             isExperimental: isExperimental,
             changeDescription: 'Package dependency removed: "$dependencyName"',
           ),
@@ -1107,9 +1107,9 @@ class PackageApiDiffer {
             changeCode: ApiChangeCode.cd03,
             affectedDeclaration: null,
             contextTrace: [],
-            type: isNonBreakingVersionChange
-                ? ApiChangeType.changeCompatible
-                : ApiChangeType.changeBreaking,
+            type: !isNonBreakingVersionChange
+                ? ApiChangeType.changeBreaking
+                : ApiChangeType.changeCompatiblePatch,
             isExperimental: isExperimental,
             changeDescription:
                 'Package dependency "$dependencyName" version changed from "${oldDependency.packageVersion}" to "${newDependency.packageVersion}"',
@@ -1159,7 +1159,7 @@ class PackageApiDiffer {
         affectedDeclaration: affectedDeclaration,
         contextTrace: _contextTraceFromStack(context),
         type: isCompatibleChange
-            ? ApiChangeType.changeCompatible
+            ? ApiChangeType.changeCompatibleMinor
             : ApiChangeType.changeBreaking,
         changeDescription: changeDescription,
         isExperimental: isExperimental,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A tool to analyze the public API of a package, create a model of it
 homepage: https://devmil.de
 repository: https://github.com/devmil/dart_apitool
 
-version: 0.11.2-dev
+version: 0.12.0-dev
 
 environment:
   sdk: ">=2.17.5 <3.0.0"

--- a/readme/change_codes.md
+++ b/readme/change_codes.md
@@ -18,10 +18,10 @@ Adding a new interface is an API change but a non-breaking one.
 ### <a name="CI03" />An interface is renamed (CI03)
 dart-apitool is treating this as removal of the old interface and addition of the new interface. So a breaking change (remove) and a non-breaking change (add).
 
-### <a name="CI04" />supertype added (CI04)
+### <a name="CI04" />Supertype added (CI04)
 Adding a supertype extends the API of the interface and therefore is a non-breaking change.
 
-### <a name="CI05" />supertype removed (CI05)
+### <a name="CI05" />Supertype removed (CI05)
 Removing a supertype potentially reduces the API of an interface and therefore is a breaking change.
 
 ### <a name="CI06" />The type parameters of an interface are changed (generic) (CI06)
@@ -116,7 +116,7 @@ Entry points are the imports that lead to this type being usable. Any change in 
 ### <a name="CP01" />New entry point (CP01)
 Means a type is accessible through an additional entry point. Non-breaking change
 
-### <a name="CP02" />entry point removed (CP02)
+### <a name="CP02" />Entry point removed (CP02)
 Means a type is no longer accessible through an entry point. This is a breaking change as it can break users code
 
 ## Dependencies
@@ -124,10 +124,11 @@ Means a type is no longer accessible through an entry point. This is a breaking 
 This is a breaking change. This might not be obvious but adding a dependency can lead to a broken build of the user's code. For example, if the user is using a dependency that is not compatible with the new dependency then the user's code will not build.
 
 ### <a name="CD02" />A dependency is removed (CD02)
-This is a non-breaking change. The user's code might rely on that dependency transitively but this is bad practice anyways ;)
+This is a non-breaking change. The user's code might rely on that dependency transitively, but this is bad practice anyway ;)
 
 ### <a name="CD03" />A dependency version is changed (CD03)
-This depends on the kind of version change. If the change is a patch or minor upgrade (so still in semver range) then the change is non-breaking. If the upgrade is a major upgrade then the change is breaking.
+This depends on the kind of version change. If the change is a patch or minor upgrade (so still in semver range) then the change is non-breaking. If the upgrade is a major upgrade then the change is breaking. 
+Changes here only require a patch level version bump.
 
 ## Platform
 Changes to the platform and its constraints are breaking if they are stricter than before. This means if the user's code is not compatible with the new constraints then the user's code will not build.

--- a/test/integration_tests/diff/cloud_firestore_test.dart
+++ b/test/integration_tests/diff/cloud_firestore_test.dart
@@ -1,0 +1,31 @@
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+
+import '../helper/integration_test_helper.dart';
+
+void main() {
+  group('flutter_blue version diff', () {
+    group('4.3.1 to 4.3.2', () {
+      final packageName = 'cloud_firestore';
+      final retriever_4_3_1 = PackageApiRetriever(packageName, '4.3.1');
+      final retriever_4_3_2 = PackageApiRetriever(packageName, '4.3.2');
+      late PackageApiDiffResult diffResult;
+
+      setUpAll(() async {
+        diffResult = PackageApiDiffer().diff(
+            oldApi: await retriever_4_3_1.retrieve(),
+            newApi: await retriever_4_3_2.retrieve());
+      });
+
+      test('compatible dependency changes lead to an expected patch change',
+          () {
+        expect(
+            diffResult.apiChanges.every(
+              (element) =>
+                  !element.type.requiresMinorBump && !element.type.isBreaking,
+            ),
+            isTrue);
+      });
+    });
+  });
+}

--- a/test/integration_tests/diff/flutter_blue_test.dart
+++ b/test/integration_tests/diff/flutter_blue_test.dart
@@ -54,7 +54,7 @@ void main() {
             allowAddDiffResult.apiChanges.any((element) =>
                 element.changeDescription.contains('dependency') &&
                 element.changeDescription.contains('rxdart') &&
-                element.type == ApiChangeType.addCompatible),
+                element.type == ApiChangeType.addCompatibleMinor),
             isTrue);
         // changes are still breaking
         expect(

--- a/test/integration_tests/diff/xterm_test.dart
+++ b/test/integration_tests/diff/xterm_test.dart
@@ -34,7 +34,7 @@ void main() {
       test('contains "enableSuggestions" parameter addition', () {
         expect(
             diffResult.apiChanges.any((change) =>
-                change.type == ApiChangeType.addCompatible &&
+                change.type == ApiChangeType.addCompatibleMinor &&
                 change.changeDescription.contains('enableSuggestions')),
             isTrue);
       });
@@ -62,14 +62,14 @@ void main() {
                 element.changeDescription.contains('meta') &&
                 element.changeDescription.contains('^1.1.8') &&
                 element.changeDescription.contains('^1.3.0') &&
-                element.type == ApiChangeType.changeCompatible),
+                element.type == ApiChangeType.changeCompatiblePatch),
             isTrue);
         expect(
             diffResult.apiChanges.any((element) =>
                 element.changeDescription.contains('dependency') &&
                 element.changeDescription.contains('async') &&
                 element.changeDescription.contains('removed') &&
-                element.type == ApiChangeType.removeCompatible),
+                element.type == ApiChangeType.changeCompatiblePatch),
             isTrue);
         expect(
             diffResult.apiChanges.any((element) =>

--- a/test/package_api_differ_test.dart
+++ b/test/package_api_differ_test.dart
@@ -26,7 +26,7 @@ void main() {
       final newClassApiChange = diffResult.apiChanges.first;
       expect(
           newClassApiChange.affectedDeclaration, isA<InterfaceDeclaration>());
-      expect(newClassApiChange.type, ApiChangeType.addCompatible);
+      expect(newClassApiChange.type, ApiChangeType.addCompatibleMinor);
       expect(newClassApiChange.changeDescription, contains('ClassB'));
       expect(newClassApiChange.contextTrace, isEmpty);
     });
@@ -54,7 +54,7 @@ void main() {
       final newExecutableApiChange = diffResult.apiChanges.first;
       expect(newExecutableApiChange.affectedDeclaration,
           isA<ExecutableDeclaration>());
-      expect(newExecutableApiChange.type, ApiChangeType.addCompatible);
+      expect(newExecutableApiChange.type, ApiChangeType.addCompatibleMinor);
       expect(
           newExecutableApiChange.changeDescription, contains('doSomething2'));
       expect(newExecutableApiChange.contextTrace, isEmpty);
@@ -83,7 +83,7 @@ void main() {
       expect(diffResult.apiChanges.length, 1);
       final newFieldApiChange = diffResult.apiChanges.first;
       expect(newFieldApiChange.affectedDeclaration, isA<FieldDeclaration>());
-      expect(newFieldApiChange.type, ApiChangeType.addCompatible);
+      expect(newFieldApiChange.type, ApiChangeType.addCompatibleMinor);
       expect(newFieldApiChange.changeDescription, contains('fieldB'));
       expect(newFieldApiChange.contextTrace, isEmpty);
     });
@@ -115,7 +115,7 @@ void main() {
           isA<InterfaceDeclaration>());
       expect(deprecatedAddedChange.contextTrace.first,
           isA<InterfaceDeclaration>());
-      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
+      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatibleMinor);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
     test('Class deprecated flag removed is detected', () {
@@ -130,7 +130,7 @@ void main() {
           isA<InterfaceDeclaration>());
       expect(deprecatedAddedChange.contextTrace.first,
           isA<InterfaceDeclaration>());
-      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
+      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatibleMinor);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
 
@@ -151,7 +151,7 @@ void main() {
           isA<ExecutableDeclaration>());
       expect(deprecatedAddedChange.contextTrace.first,
           isA<ExecutableDeclaration>());
-      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
+      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatibleMinor);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
     test('Executable deprecated flag removed is detected', () {
@@ -166,7 +166,7 @@ void main() {
           isA<ExecutableDeclaration>());
       expect(deprecatedAddedChange.contextTrace.first,
           isA<ExecutableDeclaration>());
-      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
+      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatibleMinor);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
 
@@ -186,7 +186,7 @@ void main() {
       expect(
           deprecatedAddedChange.affectedDeclaration, isA<FieldDeclaration>());
       expect(deprecatedAddedChange.contextTrace.first, isA<FieldDeclaration>());
-      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
+      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatibleMinor);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
     test('Field deprecated flag removed is detected', () {
@@ -200,7 +200,7 @@ void main() {
       expect(
           deprecatedAddedChange.affectedDeclaration, isA<FieldDeclaration>());
       expect(deprecatedAddedChange.contextTrace.first, isA<FieldDeclaration>());
-      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatible);
+      expect(deprecatedAddedChange.type, ApiChangeType.changeCompatibleMinor);
       expect(deprecatedAddedChange.changeDescription, contains('Deprecated'));
     });
   });
@@ -519,7 +519,7 @@ void main() {
       expect(typeChange.affectedDeclaration, isA<ExecutableDeclaration>());
       expect(typeChange.changeDescription, contains('optionalPositional'));
       expect(typeChange.contextTrace.first, isA<ExecutableDeclaration>());
-      expect(typeChange.type, ApiChangeType.addCompatible);
+      expect(typeChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('New, optional named parameter added', () {
       final differ = PackageApiDiffer();
@@ -532,7 +532,7 @@ void main() {
       expect(typeChange.affectedDeclaration, isA<ExecutableDeclaration>());
       expect(typeChange.changeDescription, contains('optionalNamed'));
       expect(typeChange.contextTrace.first, isA<ExecutableDeclaration>());
-      expect(typeChange.type, ApiChangeType.addCompatible);
+      expect(typeChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('New, required positional parameter added', () {
       final differ = PackageApiDiffer();
@@ -622,7 +622,7 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 2);
       final addChange = diffResult.apiChanges.singleWhere(
-          (element) => element.type == ApiChangeType.addCompatible);
+          (element) => element.type == ApiChangeType.addCompatibleMinor);
       final removeChange = diffResult.apiChanges
           .singleWhere((element) => element.type == ApiChangeType.remove);
       expect(removeChange.affectedDeclaration, isA<FieldDeclaration>());
@@ -635,7 +635,7 @@ void main() {
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
       expect(addChange.contextTrace.first, isA<FieldDeclaration>());
-      expect(addChange.type, ApiChangeType.addCompatible);
+      expect(addChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('EntryPoint add in field detected', () {
       final differ = PackageApiDiffer();
@@ -650,7 +650,7 @@ void main() {
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
       expect(addChange.contextTrace.first, isA<FieldDeclaration>());
-      expect(addChange.type, ApiChangeType.addCompatible);
+      expect(addChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('EntryPoint remove in field detected', () {
       final differ = PackageApiDiffer();
@@ -674,7 +674,7 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 2);
       final addChange = diffResult.apiChanges.singleWhere(
-          (element) => element.type == ApiChangeType.addCompatible);
+          (element) => element.type == ApiChangeType.addCompatibleMinor);
       final removeChange = diffResult.apiChanges
           .singleWhere((element) => element.type == ApiChangeType.remove);
       expect(removeChange.affectedDeclaration, isA<ExecutableDeclaration>());
@@ -687,7 +687,7 @@ void main() {
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
       expect(addChange.contextTrace.first, isA<ExecutableDeclaration>());
-      expect(addChange.type, ApiChangeType.addCompatible);
+      expect(addChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('EntryPoint add in executable detected', () {
       final differ = PackageApiDiffer();
@@ -702,7 +702,7 @@ void main() {
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
       expect(addChange.contextTrace.first, isA<ExecutableDeclaration>());
-      expect(addChange.type, ApiChangeType.addCompatible);
+      expect(addChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('EntryPoint remove in executable detected', () {
       final differ = PackageApiDiffer();
@@ -726,7 +726,7 @@ void main() {
       );
       expect(diffResult.apiChanges.length, 2);
       final addChange = diffResult.apiChanges.singleWhere(
-          (element) => element.type == ApiChangeType.addCompatible);
+          (element) => element.type == ApiChangeType.addCompatibleMinor);
       final removeChange = diffResult.apiChanges
           .singleWhere((element) => element.type == ApiChangeType.remove);
       expect(removeChange.affectedDeclaration, isA<InterfaceDeclaration>());
@@ -739,7 +739,7 @@ void main() {
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
       expect(addChange.contextTrace.first, isA<InterfaceDeclaration>());
-      expect(addChange.type, ApiChangeType.addCompatible);
+      expect(addChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('EntryPoint add in class detected', () {
       final differ = PackageApiDiffer();
@@ -754,7 +754,7 @@ void main() {
       expect(addChange.changeDescription, contains('entry point'));
       expect(addChange.changeDescription, contains('b.dart'));
       expect(addChange.contextTrace.first, isA<InterfaceDeclaration>());
-      expect(addChange.type, ApiChangeType.addCompatible);
+      expect(addChange.type, ApiChangeType.addCompatibleMinor);
     });
     test('EntryPoint remove in class detected', () {
       final differ = PackageApiDiffer();


### PR DESCRIPTION
Changes in dependencies that are compatible only lead to an expected patch version increase.
The same goes for dependency removals.

fixes #105