### PR TITLE
fix: don't collect constructors of private classes

### DIFF
--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -204,6 +204,10 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
       if (element.enclosingElement2 is EnumElement2) {
         return false;
       }
+      // constructors of private classes aren't collected
+      if (element.enclosingElement2.isPrivate) {
+        return false;
+      }
     }
     // don't collect any override -> already part of the source
     if (element is Annotatable &&

--- a/test/integration_tests/diff/native_test.dart
+++ b/test/integration_tests/diff/native_test.dart
@@ -40,5 +40,26 @@ void main() {
         expect(breakingChanges, []);
       });
     });
+
+    group('objective_c', () {
+      late final PackageApi objcApi;
+      final refObjc = '0924cb0e80ed6ac39298363fabe0916808a4a1fe';
+
+      setUp(() async {
+        final objcRetriever = GitPackageApiRetriever(
+          gitUrl,
+          refObjc,
+          relativePackagePath: 'pkgs/objective_c',
+        );
+        objcApi = await objcRetriever.retrieve();
+      });
+
+      test('_FinalizablePointer should not be leaked in the public API',
+          () async {
+        final hasFinalizablePointer = objcApi.interfaceDeclarations
+            .any((id) => id.name == '_FinalizablePointer');
+        expect(hasFinalizablePointer, isFalse);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description
Constructors of private classes are treated like public class constructors meaning every type passed in is treated as "used".
In practice there is no way to call the constructor of a private class from outside.
This PR stops type analysis at constructors of private classes.

Fixes #244

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
