### PR TITLE
Allow for hyphens in package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.23.1-dev
 - Fix type hierarchy calculations when the type no longer is known by the new public API
+- Fix hyphens in packages bug.
 
 ## Version 0.23.0
 - technical: use package_config to interact with package configs

--- a/lib/src/tooling/pub_interaction.dart
+++ b/lib/src/tooling/pub_interaction.dart
@@ -90,14 +90,12 @@ abstract class PubInteraction {
       for (final potentialPackageDir
           in repositoryDir.listSync().whereType<Directory>()) {
         final packageDirName = path.basename(potentialPackageDir.path);
-        final dirParts = packageDirName.split('-').toList();
-        final versionPart = dirParts.last;
-        dirParts.removeLast();
-        final packageNamePart = dirParts.join('-');
 
-        if (packageNamePart != packageName) {
+        if (!packageDirName.startsWith('$packageName-')) {
           continue;
         }
+
+        final versionPart = packageDirName.substring(packageName.length + 1);
 
         final version = Version.parse(versionPart);
         versions[version] = potentialPackageDir.path;

--- a/test/integration_tests/pub_interaction_test.dart
+++ b/test/integration_tests/pub_interaction_test.dart
@@ -6,12 +6,14 @@ import 'package:path/path.dart' as path;
 
 void main() {
   group('Pub Interaction', () {
+    // Cleanup for standard test
     setUp(() async {
       await PubInteraction.removePackageFromCache('every_test', '1.0.0');
     });
     tearDown(() async {
       await PubInteraction.removePackageFromCache('every_test', '1.0.0');
     });
+
     test('Install package to cache works', () async {
       final packagePath =
           await PubInteraction.installPackageToCache('every_test', '1.0.0');
@@ -22,6 +24,24 @@ void main() {
       expect(File(path.join(packagePath, 'pubspec.yaml')).existsSync(), isTrue,
           reason:
               'Check if the package path contains a pubspec.yaml which is an indication for a legit package.');
+    });
+
+    test(
+        'Install package to cache works for pre-release versions containing a hyphen',
+        () async {
+      const packageName = 'genkit_firebase_ai';
+      const version = '0.0.1-dev.1';
+
+      await PubInteraction.removePackageFromCache(packageName, version);
+      try {
+        await PubInteraction.installPackageToCache(packageName, version);
+
+        final packages =
+            PubInteraction.getAllPackageVersionsForPackageInCache(packageName);
+        expect(packages, isNotEmpty);
+      } finally {
+        await PubInteraction.removePackageFromCache(packageName, version);
+      }
     });
   });
 }


### PR DESCRIPTION
Before this fix, running 
```
dart pub global run dart_apitool:main diff --no-check-sdk-version --old pub://genkit_firebase_ai --new .
```
would fail with
```
No version for genkit_firebase_ai specified, using latest version
Error: No version of genkit_firebase_ai found
```
While it actually exists in the pub cache.

The reason seems to be a hyphen in the version, leading to parsing errors. This fixes that.