### PR TITLE
feat: add --set-exit-on-version-check-failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Usage: dart-apitool diff [arguments]
                                          (defaults to on)
     --[no-]ignore-requiredness           Whether to ignore the required aspect of interfaces 
                                          (yielding less strict version bump requirements)
+    --[no-]set-exit-on-version-check-failure Sets exit code to != 0 if the 
+                                         version check fails. Has no effect if 
+                                         --version-check-mode=none.
+                                         (defaults to on)
     --report-format                      Which output format should be used
                                          [cli (default), markdown, json]
     --report-file-path                   Where to store the report file (no effect on cli option)

--- a/lib/src/cli/commands/diff_command.dart
+++ b/lib/src/cli/commands/diff_command.dart
@@ -23,6 +23,8 @@ String _optionNameCheckSdkVersion = 'check-sdk-version';
 String _optionNameDependencyCheckMode = 'dependency-check-mode';
 String _optionNameRemoveExample = 'remove-example';
 String _optionNameIgnoreRequiredness = 'ignore-requiredness';
+String _optionNameSetExitOnVersionCheckFailure =
+    'set-exit-on-version-check-failure';
 String _optionReportFormat = 'report-format';
 String _optionReportPath = 'report-file-path';
 
@@ -106,6 +108,15 @@ Whether to ignore the required aspect of interfaces
       defaultsTo: false,
       negatable: true,
     );
+    argParser.addFlag(
+      _optionNameSetExitOnVersionCheckFailure,
+      help: '''
+Sets exit code to != 0 if the version check fails.
+Has no effect if --version-check-mode=none.
+''',
+      defaultsTo: true,
+      negatable: true,
+    );
     argParser.addOption(
       _optionReportFormat,
       help: 'Which output format should be used',
@@ -152,6 +163,8 @@ Whether to ignore the required aspect of interfaces
     }
     final doIgnoreRequiredness =
         argResults![_optionNameIgnoreRequiredness] as bool;
+    final setExitOnVersionCheckFailure =
+        argResults![_optionNameSetExitOnVersionCheckFailure] as bool;
 
     final preparedOldPackageRef = await prepare(
       argResults!,
@@ -215,10 +228,11 @@ Whether to ignore the required aspect of interfaces
 
     stdout.writeln('-- Generating report using: ${reporter.reporterName} --');
     await reporter.generateReport(diffResult, versionCheckResult);
-    if (versionCheckResult?.success ?? true) {
-      return 0;
-    } else {
+    if (versionCheckResult != null &&
+        !versionCheckResult.success &&
+        setExitOnVersionCheckFailure) {
       return -1;
     }
+    return 0;
   }
 }

--- a/test/integration_tests/cli/diff_command_test.dart
+++ b/test/integration_tests/cli/diff_command_test.dart
@@ -183,5 +183,36 @@ void main() {
       },
       timeout: integrationTestTimeout,
     );
+
+    test(
+      'diffing grpc 3.2.3 to 3.2.2 fails version check by default',
+      () async {
+        final exitCode = await runner.run([
+          'diff',
+          '--old',
+          'pub://grpc/3.2.3',
+          '--new',
+          'pub://grpc/3.2.2',
+        ]);
+        expect(exitCode, -1);
+      },
+      timeout: integrationTestTimeout,
+    );
+
+    test(
+      'diffing grpc 3.2.3 to 3.2.2 works with --no-set-exit-on-version-check-failure',
+      () async {
+        final exitCode = await runner.run([
+          'diff',
+          '--old',
+          'pub://grpc/3.2.3',
+          '--new',
+          'pub://grpc/3.2.2',
+          '--no-set-exit-on-version-check-failure',
+        ]);
+        expect(exitCode, 0);
+      },
+      timeout: integrationTestTimeout,
+    );
   });
 }


### PR DESCRIPTION
<!--
  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
-->

## Description

Adds a new flag that allows the tool to exit with a zero status code even if the version check failed.

My use case is that I have a large number of programmatically-generated packages and I want to use `package:dart_apitool` to suggest version upgrades. So the version check is always expected to fail.

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [X] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
