### PR TITLE
refactor: remove pubspec_manager, stack, tuple, and plist_parser dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.23.3
+- Remove unused `pubspec_manager` dependency.
+- Replace `stack`, `tuple`, and `plist_parser` dependencies with Dart SDK equivalents.
+
 ## Version 0.23.2
 - `--set-exit-on-version-check-failure` to suppress exit code != 0 in case a mismatch is detected
 

--- a/lib/src/analyze/constraints/ios_platform_contraints_helper.dart
+++ b/lib/src/analyze/constraints/ios_platform_contraints_helper.dart
@@ -1,10 +1,14 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:plist_parser/plist_parser.dart';
 import '../../model/model.dart';
 
 abstract class IOSPlatformConstraintsHelper {
+  static final _minimumOSVersionPlistPattern = RegExp(
+      r'<key>\s*MinimumOSVersion\s*<\/key>\s*<string>\s*(?<num>[0-9.]+)\s*<\/string>');
+  static final _minimumOSVersionPodspecPattern =
+      RegExp(r"platform\s*=\s*:ios\s*,\s*'(?<num>[0-9.]+)'");
+
   /// determines the AndroidPlaformConstrants for the given package path
   static Future<IOSPlatformConstraints?> getIOSPlatformConstraints({
     required String packagePath,
@@ -22,17 +26,18 @@ abstract class IOSPlatformConstraintsHelper {
         minimumOsVersion: null,
       );
       for (final plistFile in plistFiles) {
-        final plistContent = await PlistParser().parseFile(plistFile.path);
-        if (plistContent.containsKey('MinimumOSVersion')) {
-          final minimumOsVersionString = plistContent['MinimumOSVersion'];
-          final minimumOsVersion = num.tryParse(minimumOsVersionString);
-          if (minimumOsVersion != null) {
-            if (iosPlatformConstraints.minimumOsVersion == null ||
-                iosPlatformConstraints.minimumOsVersion! < minimumOsVersion) {
-              iosPlatformConstraints = iosPlatformConstraints.copyWith(
-                minimumOsVersion: minimumOsVersion,
-              );
-            }
+        if (plistFile is! File) {
+          continue;
+        }
+        final plistContent = await plistFile.readAsString();
+        final minimumOsVersion =
+            _getMinimumOsVersionFromPlistContent(plistContent);
+        if (minimumOsVersion != null) {
+          if (iosPlatformConstraints.minimumOsVersion == null ||
+              iosPlatformConstraints.minimumOsVersion! < minimumOsVersion) {
+            iosPlatformConstraints = iosPlatformConstraints.copyWith(
+              minimumOsVersion: minimumOsVersion,
+            );
           }
         }
       }
@@ -63,16 +68,18 @@ abstract class IOSPlatformConstraintsHelper {
     return null;
   }
 
+  static num? _getMinimumOsVersionFromPlistContent(String plistContent) {
+    if (_minimumOSVersionPlistPattern.firstMatch(plistContent)
+        case final match?) {
+      return num.tryParse(match.namedGroup('num')!);
+    }
+    return null;
+  }
+
   static num? _getMinimumOsVersionFromPodspecContent(String podspecContent) {
-    final minimumOsVersionMatches =
-        RegExp(r"platform\s*=\s*:ios\s*,\s*'(?<num>[0-9.]+)'")
-            .allMatches(podspecContent);
-    if (minimumOsVersionMatches.isNotEmpty) {
-      final minimumOsVersionString =
-          minimumOsVersionMatches.first.namedGroup('num');
-      if (minimumOsVersionString != null) {
-        return num.tryParse(minimumOsVersionString);
-      }
+    if (_minimumOSVersionPodspecPattern.firstMatch(podspecContent)
+        case final match?) {
+      return num.tryParse(match.namedGroup('num')!);
     }
     return null;
   }

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -3,8 +3,6 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:lumberdash/lumberdash.dart';
 import 'package:pub_semver/pub_semver.dart';
-import 'package:stack/stack.dart';
-import 'package:tuple/tuple.dart';
 
 import '../model/model.dart';
 import '../errors/errors.dart';
@@ -52,21 +50,21 @@ class PackageApiDiffer {
         ..._calculateInterfacesDiff(
           oldApi.interfaceDeclarations,
           newApi.interfaceDeclarations,
-          Stack<Declaration>(),
+          <Declaration>[],
           isExperimental: false,
           typeHierarchy: mergedTypeHierarchy,
         ),
         ..._calculateExecutablesDiff(
           oldApi.executableDeclarations,
           newApi.executableDeclarations,
-          Stack<Declaration>(),
+          <Declaration>[],
           isExperimental: false,
           typeHierarchy: mergedTypeHierarchy,
         ),
         ..._calculateFieldsDiff(
           oldApi.fieldDeclarations,
           newApi.fieldDeclarations,
-          Stack<Declaration>(),
+          <Declaration>[],
           isExperimental: false,
           typeHierarchy: mergedTypeHierarchy,
         ),
@@ -128,7 +126,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateInterfacesDiff(
     List<InterfaceDeclaration> oldInterfaces,
     List<InterfaceDeclaration> newInterfaces,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -200,7 +198,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateInterfaceDiff(
     InterfaceDeclaration oldInterface,
     InterfaceDeclaration newInterface,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -290,7 +288,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateExecutablesDiff(
     List<ExecutableDeclaration> oldExecutables,
     List<ExecutableDeclaration> newExecutables,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
@@ -360,7 +358,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateExecutableDiff(
     ExecutableDeclaration oldExecutable,
     ExecutableDeclaration newExecutable,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
@@ -450,11 +448,10 @@ class PackageApiDiffer {
     });
   }
 
-  /// returns a [Tuple2] containing
-  /// - a [bool] indicating that the order between old and new changed amd
+  /// returns a record containing
+  /// - a [bool] indicating that the order between old and new changed and
   /// - a [Map] between old parameters and new parameters that match
-  Tuple2<bool,
-          Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>>
+  (bool, Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>)
       _findMatchesByName(
     List<ExecutableParameterDeclaration> oldParameters,
     List<ExecutableParameterDeclaration> newParameters,
@@ -481,7 +478,7 @@ class PackageApiDiffer {
         result[oldParameter] = matchingNewParameter;
       }
     }
-    return Tuple2(reordered, result);
+    return (reordered, result);
   }
 
   /// returns a [Map] between old parameters and new parameters that match
@@ -503,11 +500,10 @@ class PackageApiDiffer {
     return result;
   }
 
-  /// returns a [Tuple2] containing
-  /// - a [bool] indicating that the order between old and new changed amd
+  /// returns a record containing
+  /// - a [bool] indicating that the order between old and new changed and
   /// - a [Map] between old parameters and new parameters that match
-  Tuple2<bool,
-          Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>>
+  (bool, Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>)
       _findMatchingParameters(
     List<ExecutableParameterDeclaration> oldParameters,
     List<ExecutableParameterDeclaration> newParameters,
@@ -517,8 +513,8 @@ class PackageApiDiffer {
     // 1st, find matching names
     final matchedByNameTuple =
         _findMatchesByName(oldParametersCopy, newParametersCopy);
-    final reordered = matchedByNameTuple.item1;
-    final matchedByName = matchedByNameTuple.item2;
+    final reordered = matchedByNameTuple.$1;
+    final matchedByName = matchedByNameTuple.$2;
     // 2. remove them from the list
     for (final matchedOldParameter in matchedByName.keys) {
       oldParametersCopy.remove(matchedOldParameter);
@@ -531,21 +527,21 @@ class PackageApiDiffer {
         <ExecutableParameterDeclaration, ExecutableParameterDeclaration>{};
     result.addAll(matchedByName);
     result.addAll(matchedByTypeOrder);
-    return Tuple2(reordered, result);
+    return (reordered, result);
   }
 
   List<ApiChange> _calculateParametersDiff(
     List<ExecutableParameterDeclaration> oldParameters,
     List<ExecutableParameterDeclaration> newParameters,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
     final parameterMatchesTuple =
         _findMatchingParameters(oldParameters, newParameters);
-    final parameterMatches = parameterMatchesTuple.item2;
-    final reordered = parameterMatchesTuple.item1;
+    final parameterMatches = parameterMatchesTuple.$2;
+    final reordered = parameterMatchesTuple.$1;
 
     final changes = <ApiChange>[];
     final oldParametersCopy = [...oldParameters];
@@ -572,7 +568,7 @@ class PackageApiDiffer {
     for (final removedParameter in oldParametersCopy) {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.ce01,
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         contextTrace: _contextTraceFromStack(context),
         type: ApiChangeType.remove,
         isExperimental: isExperimental,
@@ -582,7 +578,7 @@ class PackageApiDiffer {
     for (final addedParameter in newParametersCopy) {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.ce02,
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         contextTrace: _contextTraceFromStack(context),
         type: (isInterfaceRequired ?? false) || addedParameter.isRequired
             ? ApiChangeType.addBreaking
@@ -596,7 +592,7 @@ class PackageApiDiffer {
     if (reordered) {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.ce04,
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         contextTrace: _contextTraceFromStack(context),
         type: ApiChangeType.changeBreaking,
         isExperimental: isExperimental,
@@ -610,7 +606,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateParameterDiff(
     ExecutableParameterDeclaration oldParam,
     ExecutableParameterDeclaration newParam,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -696,7 +692,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateEntryPointsDiff(
     Set<String>? oldEntryPoints,
     Set<String>? newEntryPoints,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
   }) {
     if (oldEntryPoints == null || newEntryPoints == null) {
@@ -714,7 +710,7 @@ class PackageApiDiffer {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.cp01,
         contextTrace: _contextTraceFromStack(context),
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         changeDescription: 'New entry point: $newEntryPoint',
         type: ApiChangeType.addCompatibleMinor,
         isExperimental: isExperimental,
@@ -724,7 +720,7 @@ class PackageApiDiffer {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.cp02,
         contextTrace: _contextTraceFromStack(context),
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         changeDescription: 'Entry point removed: $oldEntryPoint',
         type: ApiChangeType.remove,
         isExperimental: isExperimental,
@@ -736,7 +732,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateTypeParametersDiff(
     List<String> oldTypeParameterNames,
     List<String> newTypeParameterNames,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
   }) {
@@ -747,7 +743,7 @@ class PackageApiDiffer {
           ApiChange(
             changeCode: ApiChangeCode.ci06,
             contextTrace: _contextTraceFromStack(context),
-            affectedDeclaration: context.top(),
+            affectedDeclaration: context.last,
             type: (isInterfaceRequired ?? false) ||
                     oldTypeParameterNames.length < newTypeParameterNames.length
                 ? ApiChangeType.addBreaking
@@ -766,7 +762,7 @@ class PackageApiDiffer {
       for (final removedTypeParameter in tpnListDiff.remainingOld) {
         changes.add(ApiChange(
             changeCode: ApiChangeCode.ci08,
-            affectedDeclaration: context.top(),
+            affectedDeclaration: context.last,
             contextTrace: _contextTraceFromStack(context),
             type: ApiChangeType.remove,
             isExperimental: isExperimental,
@@ -776,7 +772,7 @@ class PackageApiDiffer {
       for (final addedTypeParameter in tpnListDiff.remainingNew) {
         changes.add(ApiChange(
             changeCode: ApiChangeCode.ci07,
-            affectedDeclaration: context.top(),
+            affectedDeclaration: context.last,
             contextTrace: _contextTraceFromStack(context),
             type: ApiChangeType.addBreaking,
             isExperimental: isExperimental,
@@ -790,7 +786,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateSuperTypesDiff(
     Set<String> oldSuperTypes,
     Set<String> newSuperTypes,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
   }) {
     final stpnListDiff = _diffIterables<String>(
@@ -821,7 +817,7 @@ class PackageApiDiffer {
       changes.add(ApiChange(
           changeCode:
               ApiChangeCode.ci12, // New change code for supertype changes
-          affectedDeclaration: context.top(),
+          affectedDeclaration: context.last,
           contextTrace: _contextTraceFromStack(context),
           type: ApiChangeType
               .changeBreaking, // Supertype changes are typically breaking
@@ -833,7 +829,7 @@ class PackageApiDiffer {
     for (final removedSuperType in remainingOld) {
       changes.add(ApiChange(
           changeCode: ApiChangeCode.ci05,
-          affectedDeclaration: context.top(),
+          affectedDeclaration: context.last,
           contextTrace: _contextTraceFromStack(context),
           type: ApiChangeType.remove,
           isExperimental: isExperimental,
@@ -843,7 +839,7 @@ class PackageApiDiffer {
     for (final addedSuperType in remainingNew) {
       changes.add(ApiChange(
           changeCode: ApiChangeCode.ci04,
-          affectedDeclaration: context.top(),
+          affectedDeclaration: context.last,
           contextTrace: _contextTraceFromStack(context),
           type: ApiChangeType.addCompatibleMinor,
           isExperimental: isExperimental,
@@ -874,7 +870,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateFieldsDiff(
     List<FieldDeclaration> oldFieldDeclarations,
     List<FieldDeclaration> newFieldDeclarations,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required isExperimental,
     required TypeHierarchy typeHierarchy,
@@ -930,7 +926,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateFieldDiff(
     FieldDeclaration oldField,
     FieldDeclaration newField,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -1329,32 +1325,22 @@ class PackageApiDiffer {
     return result;
   }
 
-  List<Declaration> _contextTraceFromStack(Stack<Declaration> stack) {
-    final reverseBackup = Stack<Declaration>();
-    final result = <Declaration>[];
-    while (stack.isNotEmpty) {
-      final contextEntry = stack.pop();
-      reverseBackup.push(contextEntry);
-      result.add(contextEntry);
-    }
-    while (reverseBackup.isNotEmpty) {
-      stack.push(reverseBackup.pop());
-    }
-    return result;
+  List<Declaration> _contextTraceFromStack(List<Declaration> stack) {
+    return stack.reversed.toList();
   }
 
-  T _executeInContext<T>(Stack<Declaration> context, Declaration newContext,
-      T Function(Stack<Declaration> context) fun) {
-    context.push(newContext);
+  T _executeInContext<T>(List<Declaration> context, Declaration newContext,
+      T Function(List<Declaration> context) fun) {
+    context.add(newContext);
     final result = fun(context);
-    context.pop();
+    context.removeLast();
     return result;
   }
 
   void _compareParameterTypesAndAddChange(
     TypeIdentifier oldTypeidentifier,
     TypeIdentifier newTypeIdentifier,
-    Stack<Declaration> context,
+    List<Declaration> context,
     Declaration affectedDeclaration,
     String changeDescription,
     List<ApiChange> changes, {
@@ -1385,7 +1371,7 @@ class PackageApiDiffer {
   void _comparePropertiesAndAddChange<T>(
     T oldValue,
     T newValue,
-    Stack<Declaration> context,
+    List<Declaration> context,
     Declaration affectedDeclaration,
     String changeDescription,
     List<ApiChange> changes, {

--- a/lib/src/model/type_hierarchy.dart
+++ b/lib/src/model/type_hierarchy.dart
@@ -4,7 +4,6 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'package:path/path.dart' as path;
 import 'package:pubspec_parse/pubspec_parse.dart';
-import 'package:tuple/tuple.dart';
 
 import '../tooling/tooling.dart';
 
@@ -72,8 +71,7 @@ sealed class TypeIdentifier with _$TypeIdentifier {
         packageRelativeLibraryPath: packageRelativeLibraryPath,
       );
 
-  static final _libraryPathToPackageInfoCache =
-      <String, Tuple2<String, String>>{};
+  static final _libraryPathToPackageInfoCache = <String, (String, String)>{};
 
   factory TypeIdentifier.fromNameAndLibraryPath({
     required String typeName,
@@ -88,8 +86,8 @@ sealed class TypeIdentifier with _$TypeIdentifier {
       final cachedPackageInfo = _libraryPathToPackageInfoCache[libraryPath];
       return TypeIdentifier(
         typeName: typeName,
-        packageName: cachedPackageInfo!.item1,
-        packageRelativeLibraryPath: cachedPackageInfo.item2,
+        packageName: cachedPackageInfo!.$1,
+        packageRelativeLibraryPath: cachedPackageInfo.$2,
       );
     }
     if (libraryPath == null) {
@@ -111,7 +109,7 @@ sealed class TypeIdentifier with _$TypeIdentifier {
       final packageName = parts[0];
       // 4. the rest is the package relative library path
       final packageRelativeLibraryPath = parts.sublist(1).join('/');
-      _libraryPathToPackageInfoCache[libraryPath] = Tuple2(
+      _libraryPathToPackageInfoCache[libraryPath] = (
         packageName,
         packageRelativeLibraryPath,
       );
@@ -170,7 +168,7 @@ sealed class TypeIdentifier with _$TypeIdentifier {
     final packageRelativeLibraryPath =
         path.relative(libraryPath, from: pubspecDirectoryPath);
 
-    _libraryPathToPackageInfoCache[libraryPath] = Tuple2(
+    _libraryPathToPackageInfoCache[libraryPath] = (
       packageName,
       packageRelativeLibraryPath,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.23.2
+version: 0.23.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -19,12 +19,8 @@ dependencies:
   lumberdash: ^3.0.0
   package_config: ^2.2.0
   path: ^1.9.0
-  plist_parser: ^0.2.4
   pub_semver: ^2.2.0
-  pubspec_manager: ^1.0.0
   pubspec_parse: ^1.5.0
-  stack: ^0.2.1
-  tuple: ^2.0.0
   yaml: ^3.1.3
 
 dev_dependencies:


### PR DESCRIPTION
Remove non-core dependencies. This should hopefully make it easier to integrate this tool into the Dart SDK, with the goal of running it before `dart pub publish`. Just an idea though so far... What do you think? Remaining are just some logging libraries and `freezed_annotation`.

- Remove unused `pubspec_manager` dependency from root `pubspec.yaml`
- Replace `package:stack` (`Stack<Declaration>`) with standard Dart `List<Declaration>`
- Replace `package:tuple` (`Tuple2`) with Dart 3 Records
- Replace `package:plist_parser` with regular expression matching for `MinimumOSVersion` in plist files