### PR TITLE
refactor: remove colorize, colorize_lumberdash, console, and lumberdash dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.24.0
+- Remove `colorize`, `colorize_lumberdash`, `console`, and `lumberdash` in favor of standard ANSI escape sequences and stderr output.
+
 ## Version 0.23.3
 - Remove unused `pubspec_manager` dependency.
 - Replace `stack`, `tuple`, and `plist_parser` dependencies with Dart SDK equivalents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.23.3
+- Remove unused `pubspec_manager` dependency.
+- Replace `stack`, `tuple`, and `plist_parser` dependencies with Dart SDK equivalents.
+
 ## Version 0.23.2
 - `--set-exit-on-version-check-failure` to suppress exit code != 0 in case a mismatch is detected
 

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -3,12 +3,9 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:colorize_lumberdash/colorize_lumberdash.dart';
 import 'package:dart_apitool/api_tool_cli.dart';
-import 'package:lumberdash/lumberdash.dart';
 
 void main(List<String> arguments) async {
-  putLumberdashToWork(withClients: [ColorizeLumberdash()]);
   final runner = CommandRunner<int>('dart-apitool', '''
 dart-apitool (${ColorUtils.bold(await getOwnVersion())})
 

--- a/lib/src/analyze/constraints/ios_platform_contraints_helper.dart
+++ b/lib/src/analyze/constraints/ios_platform_contraints_helper.dart
@@ -1,10 +1,14 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:plist_parser/plist_parser.dart';
 import '../../model/model.dart';
 
 abstract class IOSPlatformConstraintsHelper {
+  static final _minimumOSVersionPlistPattern = RegExp(
+      r'<key>\s*MinimumOSVersion\s*<\/key>\s*<string>\s*(?<num>[0-9.]+)\s*<\/string>');
+  static final _minimumOSVersionPodspecPattern =
+      RegExp(r"platform\s*=\s*:ios\s*,\s*'(?<num>[0-9.]+)'");
+
   /// determines the AndroidPlaformConstrants for the given package path
   static Future<IOSPlatformConstraints?> getIOSPlatformConstraints({
     required String packagePath,
@@ -22,17 +26,18 @@ abstract class IOSPlatformConstraintsHelper {
         minimumOsVersion: null,
       );
       for (final plistFile in plistFiles) {
-        final plistContent = await PlistParser().parseFile(plistFile.path);
-        if (plistContent.containsKey('MinimumOSVersion')) {
-          final minimumOsVersionString = plistContent['MinimumOSVersion'];
-          final minimumOsVersion = num.tryParse(minimumOsVersionString);
-          if (minimumOsVersion != null) {
-            if (iosPlatformConstraints.minimumOsVersion == null ||
-                iosPlatformConstraints.minimumOsVersion! < minimumOsVersion) {
-              iosPlatformConstraints = iosPlatformConstraints.copyWith(
-                minimumOsVersion: minimumOsVersion,
-              );
-            }
+        if (plistFile is! File) {
+          continue;
+        }
+        final plistContent = await plistFile.readAsString();
+        final minimumOsVersion =
+            _getMinimumOsVersionFromPlistContent(plistContent);
+        if (minimumOsVersion != null) {
+          if (iosPlatformConstraints.minimumOsVersion == null ||
+              iosPlatformConstraints.minimumOsVersion! < minimumOsVersion) {
+            iosPlatformConstraints = iosPlatformConstraints.copyWith(
+              minimumOsVersion: minimumOsVersion,
+            );
           }
         }
       }
@@ -63,16 +68,18 @@ abstract class IOSPlatformConstraintsHelper {
     return null;
   }
 
+  static num? _getMinimumOsVersionFromPlistContent(String plistContent) {
+    if (_minimumOSVersionPlistPattern.firstMatch(plistContent)
+        case final match?) {
+      return num.tryParse(match.namedGroup('num')!);
+    }
+    return null;
+  }
+
   static num? _getMinimumOsVersionFromPodspecContent(String podspecContent) {
-    final minimumOsVersionMatches =
-        RegExp(r"platform\s*=\s*:ios\s*,\s*'(?<num>[0-9.]+)'")
-            .allMatches(podspecContent);
-    if (minimumOsVersionMatches.isNotEmpty) {
-      final minimumOsVersionString =
-          minimumOsVersionMatches.first.namedGroup('num');
-      if (minimumOsVersionString != null) {
-        return num.tryParse(minimumOsVersionString);
-      }
+    if (_minimumOSVersionPodspecPattern.firstMatch(podspecContent)
+        case final match?) {
+      return num.tryParse(match.namedGroup('num')!);
     }
     return null;
   }

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -14,7 +14,6 @@ import 'package:dart_apitool/src/analyze/exported_files_collector.dart';
 import 'package:dart_apitool/src/model/internal/internal_declaration.dart';
 import 'package:dart_apitool/src/model/internal/internal_type_alias_declaration.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:lumberdash/lumberdash.dart';
 import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -261,7 +260,8 @@ class PackageApiAnalyzer {
           }
         }
       } on StateError catch (e) {
-        logError('Problem parsing $fileToAnalyze: $e');
+        stderr
+            .writeln(ColorUtils.redError('Problem parsing $fileToAnalyze: $e'));
       }
     }
 
@@ -298,8 +298,8 @@ class PackageApiAnalyzer {
         final fieldList = entry.fieldDeclarations.map((e) => e.name).join(', ');
         final typeAliasList =
             entry.typeAliasDeclarations.map((e) => e.name).join(', ');
-        logWarning(
-            'We encountered elements that are marked to belong to an interface but the interface is not collected!\nExecutables: $executableList\nFields: $fieldList\nTypeAliases: $typeAliasList');
+        stderr.writeln(ColorUtils.redError(
+            'Warning: We encountered elements that are marked to belong to an interface but the interface is not collected!\nExecutables: $executableList\nFields: $fieldList\nTypeAliases: $typeAliasList'));
       }
     }
 

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -3,8 +3,6 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:lumberdash/lumberdash.dart';
 import 'package:pub_semver/pub_semver.dart';
-import 'package:stack/stack.dart';
-import 'package:tuple/tuple.dart';
 
 import '../model/model.dart';
 import '../errors/errors.dart';
@@ -52,21 +50,21 @@ class PackageApiDiffer {
         ..._calculateInterfacesDiff(
           oldApi.interfaceDeclarations,
           newApi.interfaceDeclarations,
-          Stack<Declaration>(),
+          <Declaration>[],
           isExperimental: false,
           typeHierarchy: mergedTypeHierarchy,
         ),
         ..._calculateExecutablesDiff(
           oldApi.executableDeclarations,
           newApi.executableDeclarations,
-          Stack<Declaration>(),
+          <Declaration>[],
           isExperimental: false,
           typeHierarchy: mergedTypeHierarchy,
         ),
         ..._calculateFieldsDiff(
           oldApi.fieldDeclarations,
           newApi.fieldDeclarations,
-          Stack<Declaration>(),
+          <Declaration>[],
           isExperimental: false,
           typeHierarchy: mergedTypeHierarchy,
         ),
@@ -128,7 +126,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateInterfacesDiff(
     List<InterfaceDeclaration> oldInterfaces,
     List<InterfaceDeclaration> newInterfaces,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -200,7 +198,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateInterfaceDiff(
     InterfaceDeclaration oldInterface,
     InterfaceDeclaration newInterface,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -290,7 +288,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateExecutablesDiff(
     List<ExecutableDeclaration> oldExecutables,
     List<ExecutableDeclaration> newExecutables,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
@@ -360,7 +358,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateExecutableDiff(
     ExecutableDeclaration oldExecutable,
     ExecutableDeclaration newExecutable,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
@@ -450,11 +448,10 @@ class PackageApiDiffer {
     });
   }
 
-  /// returns a [Tuple2] containing
-  /// - a [bool] indicating that the order between old and new changed amd
+  /// returns a record containing
+  /// - a [bool] indicating that the order between old and new changed and
   /// - a [Map] between old parameters and new parameters that match
-  Tuple2<bool,
-          Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>>
+  (bool, Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>)
       _findMatchesByName(
     List<ExecutableParameterDeclaration> oldParameters,
     List<ExecutableParameterDeclaration> newParameters,
@@ -481,7 +478,7 @@ class PackageApiDiffer {
         result[oldParameter] = matchingNewParameter;
       }
     }
-    return Tuple2(reordered, result);
+    return (reordered, result);
   }
 
   /// returns a [Map] between old parameters and new parameters that match
@@ -503,11 +500,10 @@ class PackageApiDiffer {
     return result;
   }
 
-  /// returns a [Tuple2] containing
-  /// - a [bool] indicating that the order between old and new changed amd
+  /// returns a record containing
+  /// - a [bool] indicating that the order between old and new changed and
   /// - a [Map] between old parameters and new parameters that match
-  Tuple2<bool,
-          Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>>
+  (bool, Map<ExecutableParameterDeclaration, ExecutableParameterDeclaration>)
       _findMatchingParameters(
     List<ExecutableParameterDeclaration> oldParameters,
     List<ExecutableParameterDeclaration> newParameters,
@@ -517,8 +513,8 @@ class PackageApiDiffer {
     // 1st, find matching names
     final matchedByNameTuple =
         _findMatchesByName(oldParametersCopy, newParametersCopy);
-    final reordered = matchedByNameTuple.item1;
-    final matchedByName = matchedByNameTuple.item2;
+    final reordered = matchedByNameTuple.$1;
+    final matchedByName = matchedByNameTuple.$2;
     // 2. remove them from the list
     for (final matchedOldParameter in matchedByName.keys) {
       oldParametersCopy.remove(matchedOldParameter);
@@ -531,21 +527,21 @@ class PackageApiDiffer {
         <ExecutableParameterDeclaration, ExecutableParameterDeclaration>{};
     result.addAll(matchedByName);
     result.addAll(matchedByTypeOrder);
-    return Tuple2(reordered, result);
+    return (reordered, result);
   }
 
   List<ApiChange> _calculateParametersDiff(
     List<ExecutableParameterDeclaration> oldParameters,
     List<ExecutableParameterDeclaration> newParameters,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
     final parameterMatchesTuple =
         _findMatchingParameters(oldParameters, newParameters);
-    final parameterMatches = parameterMatchesTuple.item2;
-    final reordered = parameterMatchesTuple.item1;
+    final parameterMatches = parameterMatchesTuple.$2;
+    final reordered = parameterMatchesTuple.$1;
 
     final changes = <ApiChange>[];
     final oldParametersCopy = [...oldParameters];
@@ -572,7 +568,7 @@ class PackageApiDiffer {
     for (final removedParameter in oldParametersCopy) {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.ce01,
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         contextTrace: _contextTraceFromStack(context),
         type: ApiChangeType.remove,
         isExperimental: isExperimental,
@@ -582,7 +578,7 @@ class PackageApiDiffer {
     for (final addedParameter in newParametersCopy) {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.ce02,
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         contextTrace: _contextTraceFromStack(context),
         type: (isInterfaceRequired ?? false) || addedParameter.isRequired
             ? ApiChangeType.addBreaking
@@ -596,7 +592,7 @@ class PackageApiDiffer {
     if (reordered) {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.ce04,
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         contextTrace: _contextTraceFromStack(context),
         type: ApiChangeType.changeBreaking,
         isExperimental: isExperimental,
@@ -610,7 +606,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateParameterDiff(
     ExecutableParameterDeclaration oldParam,
     ExecutableParameterDeclaration newParam,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -696,7 +692,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateEntryPointsDiff(
     Set<String>? oldEntryPoints,
     Set<String>? newEntryPoints,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
   }) {
     if (oldEntryPoints == null || newEntryPoints == null) {
@@ -714,7 +710,7 @@ class PackageApiDiffer {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.cp01,
         contextTrace: _contextTraceFromStack(context),
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         changeDescription: 'New entry point: $newEntryPoint',
         type: ApiChangeType.addCompatibleMinor,
         isExperimental: isExperimental,
@@ -724,7 +720,7 @@ class PackageApiDiffer {
       changes.add(ApiChange(
         changeCode: ApiChangeCode.cp02,
         contextTrace: _contextTraceFromStack(context),
-        affectedDeclaration: context.top(),
+        affectedDeclaration: context.last,
         changeDescription: 'Entry point removed: $oldEntryPoint',
         type: ApiChangeType.remove,
         isExperimental: isExperimental,
@@ -736,7 +732,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateTypeParametersDiff(
     List<String> oldTypeParameterNames,
     List<String> newTypeParameterNames,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required bool isExperimental,
   }) {
@@ -747,7 +743,7 @@ class PackageApiDiffer {
           ApiChange(
             changeCode: ApiChangeCode.ci06,
             contextTrace: _contextTraceFromStack(context),
-            affectedDeclaration: context.top(),
+            affectedDeclaration: context.last,
             type: (isInterfaceRequired ?? false) ||
                     oldTypeParameterNames.length < newTypeParameterNames.length
                 ? ApiChangeType.addBreaking
@@ -766,7 +762,7 @@ class PackageApiDiffer {
       for (final removedTypeParameter in tpnListDiff.remainingOld) {
         changes.add(ApiChange(
             changeCode: ApiChangeCode.ci08,
-            affectedDeclaration: context.top(),
+            affectedDeclaration: context.last,
             contextTrace: _contextTraceFromStack(context),
             type: ApiChangeType.remove,
             isExperimental: isExperimental,
@@ -776,7 +772,7 @@ class PackageApiDiffer {
       for (final addedTypeParameter in tpnListDiff.remainingNew) {
         changes.add(ApiChange(
             changeCode: ApiChangeCode.ci07,
-            affectedDeclaration: context.top(),
+            affectedDeclaration: context.last,
             contextTrace: _contextTraceFromStack(context),
             type: ApiChangeType.addBreaking,
             isExperimental: isExperimental,
@@ -790,7 +786,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateSuperTypesDiff(
     Set<String> oldSuperTypes,
     Set<String> newSuperTypes,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
   }) {
     final stpnListDiff = _diffIterables<String>(
@@ -821,7 +817,7 @@ class PackageApiDiffer {
       changes.add(ApiChange(
           changeCode:
               ApiChangeCode.ci12, // New change code for supertype changes
-          affectedDeclaration: context.top(),
+          affectedDeclaration: context.last,
           contextTrace: _contextTraceFromStack(context),
           type: ApiChangeType
               .changeBreaking, // Supertype changes are typically breaking
@@ -833,7 +829,7 @@ class PackageApiDiffer {
     for (final removedSuperType in remainingOld) {
       changes.add(ApiChange(
           changeCode: ApiChangeCode.ci05,
-          affectedDeclaration: context.top(),
+          affectedDeclaration: context.last,
           contextTrace: _contextTraceFromStack(context),
           type: ApiChangeType.remove,
           isExperimental: isExperimental,
@@ -843,7 +839,7 @@ class PackageApiDiffer {
     for (final addedSuperType in remainingNew) {
       changes.add(ApiChange(
           changeCode: ApiChangeCode.ci04,
-          affectedDeclaration: context.top(),
+          affectedDeclaration: context.last,
           contextTrace: _contextTraceFromStack(context),
           type: ApiChangeType.addCompatibleMinor,
           isExperimental: isExperimental,
@@ -874,7 +870,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateFieldsDiff(
     List<FieldDeclaration> oldFieldDeclarations,
     List<FieldDeclaration> newFieldDeclarations,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     bool? isInterfaceRequired,
     required isExperimental,
     required TypeHierarchy typeHierarchy,
@@ -930,7 +926,7 @@ class PackageApiDiffer {
   List<ApiChange> _calculateFieldDiff(
     FieldDeclaration oldField,
     FieldDeclaration newField,
-    Stack<Declaration> context, {
+    List<Declaration> context, {
     required bool isExperimental,
     required TypeHierarchy typeHierarchy,
   }) {
@@ -1329,32 +1325,22 @@ class PackageApiDiffer {
     return result;
   }
 
-  List<Declaration> _contextTraceFromStack(Stack<Declaration> stack) {
-    final reverseBackup = Stack<Declaration>();
-    final result = <Declaration>[];
-    while (stack.isNotEmpty) {
-      final contextEntry = stack.pop();
-      reverseBackup.push(contextEntry);
-      result.add(contextEntry);
-    }
-    while (reverseBackup.isNotEmpty) {
-      stack.push(reverseBackup.pop());
-    }
-    return result;
+  List<Declaration> _contextTraceFromStack(List<Declaration> stack) {
+    return stack.reversed.toList();
   }
 
-  T _executeInContext<T>(Stack<Declaration> context, Declaration newContext,
-      T Function(Stack<Declaration> context) fun) {
-    context.push(newContext);
+  T _executeInContext<T>(List<Declaration> context, Declaration newContext,
+      T Function(List<Declaration> context) fun) {
+    context.add(newContext);
     final result = fun(context);
-    context.pop();
+    context.removeLast();
     return result;
   }
 
   void _compareParameterTypesAndAddChange(
     TypeIdentifier oldTypeidentifier,
     TypeIdentifier newTypeIdentifier,
-    Stack<Declaration> context,
+    List<Declaration> context,
     Declaration affectedDeclaration,
     String changeDescription,
     List<ApiChange> changes, {
@@ -1385,7 +1371,7 @@ class PackageApiDiffer {
   void _comparePropertiesAndAddChange<T>(
     T oldValue,
     T newValue,
-    Stack<Declaration> context,
+    List<Declaration> context,
     Declaration affectedDeclaration,
     String changeDescription,
     List<ApiChange> changes, {

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -1,8 +1,11 @@
 import 'dart:math';
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
-import 'package:lumberdash/lumberdash.dart';
 import 'package:pub_semver/pub_semver.dart';
+
+import '../utils/utils.dart';
 
 import '../model/model.dart';
 import '../errors/errors.dart';
@@ -1297,8 +1300,8 @@ class PackageApiDiffer {
         // this can happen if the API is checked on a version that will be tweaked before publishing (e.g. turn path dependencies into pub refs)
         if (oldDependency.packageVersion == null ||
             newDependency.packageVersion == null) {
-          logWarning(
-              'Package dependency "$dependencyName" has a git or path dependency in one of the APIs. Skipping version check.');
+          stderr.writeln(ColorUtils.redError(
+              'Warning: Package dependency "$dependencyName" has a git or path dependency in one of the APIs. Skipping version check.'));
           continue;
         }
         final oldVersion =

--- a/lib/src/diff/report/console_diff_reporter.dart
+++ b/lib/src/diff/report/console_diff_reporter.dart
@@ -1,7 +1,5 @@
 import 'dart:io';
 
-import 'package:console/console.dart';
-
 import '../../../api_tool.dart';
 import '../../cli/commands/version_check.dart';
 import 'diff_reporter.dart';
@@ -77,6 +75,42 @@ class ConsoleDiffReporter extends DiffReporter {
     final nodes = nodeToTree(node,
         labelOverride: breaking ? 'BREAKING CHANGES' : 'Non-Breaking changes');
 
-    return nodes.isEmpty ? null : createTree(nodes);
+    return nodes.isEmpty ? null : _createTree(nodes);
+  }
+
+  String _createTree(Map<dynamic, dynamic> tree) {
+    final buffer = StringBuffer();
+    final label = tree['label']?.toString() ?? '';
+    buffer.writeln(label);
+    if (tree['nodes'] case List<dynamic> nodes when nodes.isNotEmpty) {
+      _writeTreeNodes(buffer, nodes, '');
+    }
+    return buffer.toString();
+  }
+
+  void _writeTreeNodes(
+      StringBuffer buffer, List<dynamic> nodes, String prefix) {
+    for (var i = 0; i < nodes.length; i++) {
+      final isLast = i == nodes.length - 1;
+      final connector = isLast ? '└── ' : '├── ';
+      final node = nodes[i];
+      if (node is Map) {
+        final label = node['label']?.toString() ?? '';
+        buffer
+          ..write(prefix)
+          ..write(connector)
+          ..writeln(label);
+        if (node['nodes'] case List<dynamic> childNodes
+            when childNodes.isNotEmpty) {
+          final childPrefix = prefix + (isLast ? '    ' : '│   ');
+          _writeTreeNodes(buffer, childNodes, childPrefix);
+        }
+      } else {
+        buffer
+          ..write(prefix)
+          ..write(connector)
+          ..writeln(node);
+      }
+    }
   }
 }

--- a/lib/src/model/type_hierarchy.dart
+++ b/lib/src/model/type_hierarchy.dart
@@ -4,7 +4,6 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 import 'package:path/path.dart' as path;
 import 'package:pubspec_parse/pubspec_parse.dart';
-import 'package:tuple/tuple.dart';
 
 import '../tooling/tooling.dart';
 
@@ -72,8 +71,7 @@ sealed class TypeIdentifier with _$TypeIdentifier {
         packageRelativeLibraryPath: packageRelativeLibraryPath,
       );
 
-  static final _libraryPathToPackageInfoCache =
-      <String, Tuple2<String, String>>{};
+  static final _libraryPathToPackageInfoCache = <String, (String, String)>{};
 
   factory TypeIdentifier.fromNameAndLibraryPath({
     required String typeName,
@@ -88,8 +86,8 @@ sealed class TypeIdentifier with _$TypeIdentifier {
       final cachedPackageInfo = _libraryPathToPackageInfoCache[libraryPath];
       return TypeIdentifier(
         typeName: typeName,
-        packageName: cachedPackageInfo!.item1,
-        packageRelativeLibraryPath: cachedPackageInfo.item2,
+        packageName: cachedPackageInfo!.$1,
+        packageRelativeLibraryPath: cachedPackageInfo.$2,
       );
     }
     if (libraryPath == null) {
@@ -111,7 +109,7 @@ sealed class TypeIdentifier with _$TypeIdentifier {
       final packageName = parts[0];
       // 4. the rest is the package relative library path
       final packageRelativeLibraryPath = parts.sublist(1).join('/');
-      _libraryPathToPackageInfoCache[libraryPath] = Tuple2(
+      _libraryPathToPackageInfoCache[libraryPath] = (
         packageName,
         packageRelativeLibraryPath,
       );
@@ -170,7 +168,7 @@ sealed class TypeIdentifier with _$TypeIdentifier {
     final packageRelativeLibraryPath =
         path.relative(libraryPath, from: pubspecDirectoryPath);
 
-    _libraryPathToPackageInfoCache[libraryPath] = Tuple2(
+    _libraryPathToPackageInfoCache[libraryPath] = (
       packageName,
       packageRelativeLibraryPath,
     );

--- a/lib/src/tooling/dart_interaction.dart
+++ b/lib/src/tooling/dart_interaction.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:lumberdash/lumberdash.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:path/path.dart' as path;
 
@@ -52,12 +51,8 @@ abstract class DartInteraction {
     } else {
       final flutterExecutablePath = await _findFlutterExecutablePath();
       if (flutterExecutablePath == null) {
-        logWarning(
-          'Unable to find matching Flutter executable. Using system Flutter executable...',
-          extras: {
-            'dart executable': _getDartExecutablePath(),
-          },
-        );
+        stderr.writeln(ColorUtils.redError(
+            'Warning: Unable to find matching Flutter executable. Using system Flutter executable (dart executable: ${_getDartExecutablePath()})...'));
       }
       return _runDartOrFlutterCommand(
         flutterExecutablePath ?? 'flutter',

--- a/lib/src/utils/color_utils.dart
+++ b/lib/src/utils/color_utils.dart
@@ -1,7 +1,5 @@
 import 'dart:io';
 
-import 'package:colorize/colorize.dart';
-
 /// Utility class for handling colored terminal output.
 /// Automatically detects if stdout/stderr are attached to a terminal
 /// and disables colors when output is piped to a file.
@@ -14,44 +12,34 @@ class ColorUtils {
   static bool get shouldUseColorsForStderr =>
       stdioType(stderr) == StdioType.terminal;
 
-  /// Creates a colorized string for stdout output.
-  /// If stdout is not a terminal, returns the plain text without colors.
-  static String colorizeForStdout(
-      String text, Colorize Function(Colorize) style) {
-    if (shouldUseColorsForStdout) {
-      return style(Colorize(text)).toString();
-    }
-    return text;
-  }
-
-  /// Creates a colorized string for stderr output.
-  /// If stderr is not a terminal, returns the plain text without colors.
-  static String colorizeForStderr(
-      String text, Colorize Function(Colorize) style) {
-    if (shouldUseColorsForStderr) {
-      return style(Colorize(text)).toString();
+  static String _style(String text, String code, bool useColor) {
+    if (useColor && text.isNotEmpty) {
+      return '\x1B[${code}m$text\x1B[0m';
     }
     return text;
   }
 
   /// Convenience method for green text on stdout
-  static String green(String text) => colorizeForStdout(text, (c) => c.green());
+  static String green(String text) =>
+      _style(text, '32', shouldUseColorsForStdout);
 
   /// Convenience method for red text on stdout
-  static String red(String text) => colorizeForStdout(text, (c) => c.red());
+  static String red(String text) =>
+      _style(text, '31', shouldUseColorsForStdout);
 
   /// Convenience method for bold text on stdout
-  static String bold(String text) => colorizeForStdout(text, (c) => c.bold());
+  static String bold(String text) =>
+      _style(text, '1', shouldUseColorsForStdout);
 
   /// Convenience method for italic text on stdout
   static String italic(String text) =>
-      colorizeForStdout(text, (c) => c.italic());
+      _style(text, '3', shouldUseColorsForStdout);
 
   /// Convenience method for red text on stderr
   static String redError(String text) =>
-      colorizeForStderr(text, (c) => c.red());
+      _style(text, '31', shouldUseColorsForStderr);
 
   /// Convenience method for bold red text on stderr
   static String boldRedError(String text) =>
-      colorizeForStderr(text, (c) => c.red().bold());
+      _style(text, '1;31', shouldUseColorsForStderr);
 }

--- a/lib/src/utils/stdout_session.dart
+++ b/lib/src/utils/stdout_session.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:console/console.dart';
-
 /// defines a stdout session that supports opening a "window" for subprocesses that has a limited height
 class StdoutSession {
   final _utf8Decoder = Utf8Decoder();
@@ -39,7 +37,7 @@ class StdoutSession {
       _drawWindow();
       await stdout.flush();
     } else {
-      Console.write(stringContent);
+      stdout.write(stringContent);
     }
 
     _writeCompleter = null;
@@ -58,7 +56,7 @@ class StdoutSession {
       _windowLines.clear();
       _currentWindowSize = height;
       _drawWindow();
-      Console.hideCursor();
+      stdout.write('\x1B[?25l'); // hide cursor
     }
   }
 
@@ -67,31 +65,33 @@ class StdoutSession {
     if (_currentWindowSize != null) {
       _drawWindow(doClear: true); // erase window
       _windowLines.clear();
-      Console.moveCursorUp(_lastDrawnWindowSize!);
+      if (_lastDrawnWindowSize != null && _lastDrawnWindowSize! > 0) {
+        stdout.write('\x1B[${_lastDrawnWindowSize}A');
+      }
       _currentWindowSize = null;
       _lastDrawnWindowSize = null;
-      Console.showCursor();
+      stdout.write('\x1B[?25h'); // show cursor
     }
   }
 
   void _drawWindow({bool doClear = false}) {
-    if (_lastDrawnWindowSize != null) {
-      Console.moveCursorUp(_lastDrawnWindowSize!);
+    if (_lastDrawnWindowSize != null && _lastDrawnWindowSize! > 0) {
+      stdout.write('\x1B[${_lastDrawnWindowSize}A');
     }
     if (_shouldUseColors) {
-      Console.setTextColor(Color.GRAY.id);
+      stdout.write('\x1B[90m'); // gray text
     }
     _lastDrawnWindowSize = _windowLines.length;
     for (var i = 0; i < _windowLines.length; i++) {
-      Console.eraseLine(2);
+      stdout.write('\x1B[2K'); // erase line
       if (!doClear) {
-        Console.write('> ${_windowLines[i]}');
+        stdout.write('> ${_windowLines[i]}');
       }
-      Console.moveCursorDown();
-      Console.moveToColumn(0);
+      stdout.write('\x1B[B'); // move cursor down
+      stdout.write('\r'); // move to column 0
     }
     if (_shouldUseColors) {
-      Console.resetTextColor();
+      stdout.write('\x1B[39m'); // reset text color
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.23.3
+version: 0.24.0
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -11,12 +11,8 @@ dependencies:
   analyzer: ^10.0.2
   args: ^2.7.0
   collection: ^1.19.0
-  colorize: ^3.0.0
-  colorize_lumberdash: ^3.0.0
-  console: ^4.1.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
-  lumberdash: ^3.0.0
   package_config: ^2.2.0
   path: ^1.9.0
   pub_semver: ^2.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.23.2
+version: 0.23.3
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -19,12 +19,8 @@ dependencies:
   lumberdash: ^3.0.0
   package_config: ^2.2.0
   path: ^1.9.0
-  plist_parser: ^0.2.4
   pub_semver: ^2.2.0
-  pubspec_manager: ^1.0.0
   pubspec_parse: ^1.5.0
-  stack: ^0.2.1
-  tuple: ^2.0.0
   yaml: ^3.1.3
 
 dev_dependencies:


### PR DESCRIPTION
- Remove `package:colorize` in favor of standard ANSI escape sequences in `ColorUtils`
- Remove `package:console` in favor of standard ANSI terminal cursor control and a custom ASCII tree formatter (`_createTree`)
- Remove `package:lumberdash` and `package:colorize_lumberdash` in favor of standard `stderr.writeln` warnings and errors
- Removes 6 more dependencies from the package graph, leaving only Google-authored packages and compile-time annotation `freezed_annotation` in runtime dependencies